### PR TITLE
Fix panic in GetEQProfileV2 and improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ share
 fyne-cross
 dist/
 completions/
+research
+

--- a/cmd/kefw2/cmd/eq_profile.go
+++ b/cmd/kefw2/cmd/eq_profile.go
@@ -35,7 +35,11 @@ var eqProfileCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, _ []string) {
 		ctx := cmd.Context()
-		eqProfile, _ := currentSpeaker.GetEQProfileV2(ctx)
+		eqProfile, err := currentSpeaker.GetEQProfileV2(ctx)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error getting EQ profile: %v\n", err)
+			return
+		}
 		fmt.Println(eqProfile)
 	},
 }

--- a/kefw2/eqprofilev2.go
+++ b/kefw2/eqprofilev2.go
@@ -3,7 +3,6 @@ package kefw2
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // EQProfileV2 represents the equalizer and DSP settings for the speaker.
@@ -14,7 +13,7 @@ type EQProfileV2 struct {
 	Balance            int     `json:"balance"`            // Left/right balance (-10 to +10)
 	BassExtension      string  `json:"bassExtension"`      // Bass extension mode: "less", "standard", or "more"
 	DeskMode           bool    `json:"deskMode"`           // Whether desk mode is enabled
-	DeskModeSetting    int     `json:"deskModeSetting"`    // Desk mode compensation level
+	DeskModeSetting    float32 `json:"deskModeSetting"`    // Desk mode compensation level
 	HighPassMode       bool    `json:"highPassMode"`       // Whether high-pass filter is enabled (for use with subwoofer)
 	HighPassModeFreq   int     `json:"highPassModeFreq"`   // High-pass filter frequency in Hz
 	IsExpertMode       bool    `json:"isExpertMode"`       // Whether expert mode is enabled
@@ -39,7 +38,14 @@ type EQProfileV2 struct {
 // Each source can have its own EQ profile settings.
 func (s *KEFSpeaker) GetEQProfileV2(ctx context.Context) (EQProfileV2, error) {
 	eqProfile, err := JSONUnmarshalValue(s.getData(ctx, "kef:eqProfile/v2"))
-	return eqProfile.(EQProfileV2), err
+	if err != nil {
+		return EQProfileV2{}, err
+	}
+	profile, ok := eqProfile.(EQProfileV2)
+	if !ok {
+		return EQProfileV2{}, ErrUnknownType
+	}
+	return profile, nil
 }
 
 // String returns the EQ profile as a formatted JSON string.

--- a/kefw2/eqprofilev2.go
+++ b/kefw2/eqprofilev2.go
@@ -3,6 +3,7 @@ package kefw2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 )
 
 // EQProfileV2 represents the equalizer and DSP settings for the speaker.

--- a/kefw2/http.go
+++ b/kefw2/http.go
@@ -29,9 +29,10 @@ const (
 
 // Common errors.
 var (
-	ErrConnectionRefused = errors.New("connection refused")
-	ErrConnectionTimeout = errors.New("connection timed out")
-	ErrHostNotFound      = errors.New("host not found")
+	ErrConnectionRefused   = errors.New("connection refused")
+	ErrConnectionTimeout   = errors.New("connection timed out")
+	ErrHostNotFound        = errors.New("host not found")
+	ErrInvalidJSONResponse = errors.New("invalid JSON response")
 )
 
 // KEFPostRequest represents the JSON structure for POST requests to the KEF API.


### PR DESCRIPTION
## Summary

- Fix panic when running `kefw2 config eq_profile` caused by unsafe type assertion on nil interface
- Add proper error checking before type assertion in `GetEQProfileV2()`
- Change `DeskModeSetting` field from `int` to `float32` to match API response values (e.g., `-3.5`)
- Handle and display errors in `eq_profile` command instead of silently ignoring them