### PR TITLE
Add UPnP library search with local indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-02-03
+
+### Added
+
+- **UPnP Library Search**: New local search index for instant track searching
+  - `upnp search [query]` - Search by title, artist, or album
+  - `upnp search` (no query) - Browse full library with interactive filter
+  - `upnp index` - View index status
+  - `upnp index --rebuild` - Rebuild the search index
+  - `upnp index --container "path"` - Index from specific folder
+  - `config upnp index container` - Set default container for indexing
+  - Ranked search results with exact matches first
+  - Multi-word queries work across fields (e.g., `public enemy uzi`)
+
+- **Content Picker Improvements**
+  - Page Up/Page Down navigation for faster scrolling
+  - Filter now matches on artist/album in addition to title
+
+### Changed
+
+- `upnp play` now recursively scans sub-containers (plays all albums under an artist)
+- `upnp search` accepts multiple arguments without quotes
+
+### Fixed
+
+- Fixed `cache status` to show correct cache file and entry count
+
 ## [0.2.1] - 2026-02-02
 
 ### Added
@@ -331,7 +358,8 @@ Implemented by: `Source`, `SpeakerStatus`, `CableMode`
 
 7. **Update player ID field access**: If you access `playId.SystemMemberId`, change it to `playId.SystemMemberID`.
 
-[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/hilli/go-kef-w2/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/hilli/go-kef-w2/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/hilli/go-kef-w2/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/hilli/go-kef-w2/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -190,15 +190,59 @@ kefw2 podcast browse
 Play music from local network media servers:
 
 ```shell
-# Browse a server (with tab completion)
-kefw2 upnp browse "My NAS/Music/Albums"
+# Configure default UPnP server
+kefw2 config upnp server default "Plex Media Server: homesrv"
+
+# Browse a server interactively
+kefw2 upnp browse
+
+# Browse a specific path (with tab completion)
+kefw2 upnp browse "Music/Albums"
 
 # Play media from server
-kefw2 upnp play "My NAS/Music/Jazz/Album/Track.flac"
-
-# Configure default UPnP server
-kefw2 config upnp server "My NAS"
+kefw2 upnp play "Music/Jazz/Album/Track.flac"
 ```
+
+#### UPnP Search
+
+Search your entire music library instantly with a local index:
+
+```shell
+# Search for tracks by title, artist, or album
+kefw2 upnp search "beatles"
+kefw2 upnp search "abbey road"
+kefw2 upnp search "come together beatles"
+
+# Add search result to queue instead of playing
+kefw2 upnp search -q "bohemian"
+```
+
+The search feature builds a local index of your UPnP music library for instant results.
+The index is cached and automatically refreshes after 24 hours.
+
+#### Index Configuration
+
+For large libraries (like Plex), you can configure which folder to index to avoid
+scanning duplicate views (By Genre, By Album, etc. contain the same tracks):
+
+```shell
+# Set the container path to index (with tab completion)
+kefw2 config upnp index container "Music/Hilli's Music/All Artists"
+
+# Show current index status
+kefw2 upnp index
+
+# Rebuild the index (uses configured container automatically)
+kefw2 upnp index --rebuild
+
+# Override container for a one-time rebuild
+kefw2 upnp index --rebuild --container "Music/My Library/By Album"
+
+# Clear the container setting (index entire server)
+kefw2 config upnp index container ""
+```
+
+The container path uses `/` as separator and supports tab completion at each level.
 
 ### Queue Management
 
@@ -296,6 +340,7 @@ kefw2 events --json
 - [x] Play Podcasts
 - [x] Play from UPnP/DLNA media servers
 - [x] Queue management
+- [x] UPnP library search with local indexing
 - [ ] Restore speaker settings/eq profiles from file
 - [ ] Play titles from built-in music streaming services (Amazon Music, Deezer, Qobuz, Spotify, Tidal)
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ scanning duplicate views (By Genre, By Album, etc. contain the same tracks):
 
 ```shell
 # Set the container path to index (with tab completion)
-kefw2 config upnp index container "Music/Hilli's Music/All Artists"
+kefw2 config upnp index container "Music/Hilli's Music/By Folder"
 
 # Show current index status
 kefw2 upnp index

--- a/cmd/kefw2/cmd/config_upnp.go
+++ b/cmd/kefw2/cmd/config_upnp.go
@@ -152,9 +152,139 @@ func UPnPServerCompletion(cmd *cobra.Command, args []string, toComplete string) 
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
+// upnpIndexConfigCmd is the parent for index config subcommands
+var upnpIndexConfigCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Configure UPnP search index settings",
+	Long:  `Configure settings for the UPnP search index, including the container path to index.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+// upnpIndexContainerCmd shows or sets the index container path
+var upnpIndexContainerCmd = &cobra.Command{
+	Use:   "container [path]",
+	Short: "Show or set the container path for indexing",
+	Long: `Show the current container path for indexing, or set a new one.
+
+The container path determines which folder to start indexing from.
+Use "/" as separator for nested paths.
+
+Without arguments, displays the current setting.
+With a path, sets that as the default container to index.
+
+Examples:
+  kefw2 config upnp index container                                  # Show current
+  kefw2 config upnp index container "Music"                          # Index Music folder
+  kefw2 config upnp index container "Music/Hilli's Music/All Artists"  # Index specific folder
+  kefw2 config upnp index container ""                               # Clear (index entire server)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			// Show current setting
+			containerPath := viper.GetString("upnp.index_container")
+			if containerPath == "" {
+				contentPrinter.Println("No index container configured (will index entire server).")
+				contentPrinter.Println("Use 'kefw2 config upnp index container <path>' to set one.")
+				return
+			}
+			headerPrinter.Print("Index container: ")
+			contentPrinter.Println(containerPath)
+			return
+		}
+
+		// Set new container path
+		containerPath := args[0]
+
+		// If a path is provided, validate it exists
+		if containerPath != "" {
+			serverPath := viper.GetString("upnp.default_server_path")
+			if serverPath == "" {
+				exitWithError("No default UPnP server configured. Set one first with: kefw2 config upnp server default <name>")
+			}
+
+			client := kefw2.NewAirableClient(currentSpeaker)
+			_, resolvedPath, err := findContainerByPath(client, serverPath, containerPath)
+			if err != nil {
+				exitWithError("Invalid container path: %v", err)
+			}
+			// Use the resolved path (with proper casing)
+			containerPath = resolvedPath
+		}
+
+		// Save to config
+		viper.Set("upnp.index_container", containerPath)
+		err := viper.WriteConfig()
+		exitOnError(err, "Error saving config")
+
+		if containerPath == "" {
+			taskConpletedPrinter.Println("Index container cleared (will index entire server)")
+		} else {
+			taskConpletedPrinter.Print("Index container set: ")
+			contentPrinter.Println(containerPath)
+		}
+	},
+	ValidArgsFunction: UPnPContainerCompletion,
+}
+
+// UPnPContainerCompletion provides tab completion for container paths
+func UPnPContainerCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	if currentSpeaker == nil || currentSpeaker.IPAddress == "" {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	serverPath := viper.GetString("upnp.default_server_path")
+	if serverPath == "" {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client := kefw2.NewAirableClient(currentSpeaker)
+
+	// Parse the path to complete
+	// e.g., "Music/Hilli" -> parentPath="Music", prefix="Hilli"
+	var parentPath, prefix string
+	if idx := strings.LastIndex(toComplete, "/"); idx >= 0 {
+		parentPath = toComplete[:idx]
+		prefix = toComplete[idx+1:]
+	} else {
+		parentPath = ""
+		prefix = toComplete
+	}
+
+	// Get containers at the parent path
+	containers, err := listContainersAtPath(client, serverPath, parentPath)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	prefixLower := strings.ToLower(prefix)
+	for _, name := range containers {
+		if strings.HasPrefix(strings.ToLower(name), prefixLower) {
+			// Build the full path for completion
+			var fullPath string
+			if parentPath != "" {
+				fullPath = parentPath + "/" + name
+			} else {
+				fullPath = name
+			}
+			completions = append(completions, fullPath)
+		}
+	}
+
+	// Don't add space after completion (user might want to continue the path)
+	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+}
+
 func init() {
 	ConfigCmd.AddCommand(upnpConfigCmd)
 	upnpConfigCmd.AddCommand(upnpServerConfigCmd)
 	upnpServerConfigCmd.AddCommand(upnpServerDefaultCmd)
 	upnpServerConfigCmd.AddCommand(upnpServerListCmd)
+	upnpConfigCmd.AddCommand(upnpIndexConfigCmd)
+	upnpIndexConfigCmd.AddCommand(upnpIndexContainerCmd)
 }

--- a/cmd/kefw2/cmd/config_upnp.go
+++ b/cmd/kefw2/cmd/config_upnp.go
@@ -177,7 +177,7 @@ With a path, sets that as the default container to index.
 Examples:
   kefw2 config upnp index container                                  # Show current
   kefw2 config upnp index container "Music"                          # Index Music folder
-  kefw2 config upnp index container "Music/Hilli's Music/All Artists"  # Index specific folder
+  kefw2 config upnp index container "Music/Hilli's Music/By Folder"  # Index specific folder
   kefw2 config upnp index container ""                               # Clear (index entire server)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/cmd/kefw2/cmd/content_picker.go
+++ b/cmd/kefw2/cmd/content_picker.go
@@ -237,6 +237,21 @@ func (m ContentPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cursor++
 			}
 
+		case "pgup":
+			m.cursor -= maxVisibleItems
+			if m.cursor < 0 {
+				m.cursor = 0
+			}
+
+		case "pgdown":
+			m.cursor += maxVisibleItems
+			if m.cursor >= len(m.filtered) {
+				m.cursor = len(m.filtered) - 1
+			}
+			if m.cursor < 0 {
+				m.cursor = 0
+			}
+
 		case "enter":
 			if len(m.filtered) > 0 && m.cursor < len(m.filtered) {
 				selected := &m.filtered[m.cursor]
@@ -393,7 +408,8 @@ func (m *ContentPickerModel) applyFilter() {
 
 	m.filtered = nil
 	for _, item := range m.allItems {
-		if FuzzyMatch(item.Title, query) {
+		// Match on title, or on description (which contains artist/album for tracks)
+		if FuzzyMatch(item.Title, query) || FuzzyMatch(item.LongDescription, query) {
 			m.filtered = append(m.filtered, item)
 		}
 	}
@@ -513,7 +529,7 @@ func (m ContentPickerModel) View() string {
 	if m.callbacks.ClearQueue != nil {
 		extraHints += " | Ctrl+x: clear"
 	}
-	statusText := fmt.Sprintf("↑/↓: navigate | Type to filter | Enter: %s%s | Esc: quit", actionHint, extraHints)
+	statusText := fmt.Sprintf("↑/↓/PgUp/PgDn: navigate | Type to filter | Enter: %s%s | Esc: quit", actionHint, extraHints)
 	b.WriteString(m.styles.Status.Render(statusText))
 
 	return b.String()

--- a/cmd/kefw2/cmd/upnp_index.go
+++ b/cmd/kefw2/cmd/upnp_index.go
@@ -1,0 +1,371 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hilli/go-kef-w2/kefw2"
+)
+
+// IndexedTrack represents a track in the search index with pre-computed search fields.
+type IndexedTrack struct {
+	Title       string `json:"title"`
+	Artist      string `json:"artist"`
+	Album       string `json:"album"`
+	Path        string `json:"path"`
+	Icon        string `json:"icon,omitempty"`
+	Duration    int    `json:"duration,omitempty"` // milliseconds
+	SearchField string `json:"search_field"`       // Pre-computed lowercase "title artist album"
+}
+
+// TrackIndex represents the cached track index for a UPnP server.
+type TrackIndex struct {
+	ServerPath    string         `json:"server_path"`
+	ServerName    string         `json:"server_name"`
+	ContainerPath string         `json:"container_path,omitempty"` // Starting container (e.g., Music folder)
+	ContainerName string         `json:"container_name,omitempty"` // e.g., "Music"
+	Tracks        []IndexedTrack `json:"tracks"`
+	IndexedAt     time.Time      `json:"indexed_at"`
+	TrackCount    int            `json:"track_count"`
+	IndexVersion  int            `json:"index_version"` // For future schema changes
+}
+
+const (
+	trackIndexVersion  = 1
+	trackIndexFilename = "upnp_track_index.json"
+	defaultIndexMaxAge = 24 * time.Hour // Default: re-index if older than 24 hours
+)
+
+var (
+	trackIndexMu sync.RWMutex
+)
+
+// getTrackIndexPath returns the path to the track index file.
+func getTrackIndexPath() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+	return filepath.Join(cacheDir, "kefw2", trackIndexFilename)
+}
+
+// LoadTrackIndex loads the track index from disk.
+func LoadTrackIndex() (*TrackIndex, error) {
+	trackIndexMu.RLock()
+	defer trackIndexMu.RUnlock()
+
+	indexPath := getTrackIndexPath()
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No index yet
+		}
+		return nil, err
+	}
+
+	var index TrackIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, err
+	}
+
+	// Check version compatibility
+	if index.IndexVersion != trackIndexVersion {
+		return nil, nil // Index format changed, needs re-indexing
+	}
+
+	return &index, nil
+}
+
+// SaveTrackIndex saves the track index to disk.
+func SaveTrackIndex(index *TrackIndex) error {
+	trackIndexMu.Lock()
+	defer trackIndexMu.Unlock()
+
+	indexPath := getTrackIndexPath()
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(indexPath, data, 0644)
+}
+
+// IsTrackIndexFresh checks if the track index is fresh enough to use.
+func IsTrackIndexFresh(index *TrackIndex, maxAge time.Duration) bool {
+	if index == nil {
+		return false
+	}
+	return time.Since(index.IndexedAt) < maxAge
+}
+
+// BuildTrackIndex scans a UPnP server and builds a searchable track index.
+// If containerPath is provided (e.g., "Music/Hilli's Music/All Artists"), it will navigate to that container.
+func BuildTrackIndex(client *kefw2.AirableClient, serverPath, serverName, containerPath string, progress kefw2.IndexProgress) (*TrackIndex, error) {
+	// Determine the starting path
+	startPath := serverPath
+	actualContainerName := ""
+
+	if containerPath != "" {
+		// Navigate to the specified container
+		resolvedPath, resolvedName, err := findContainerByPath(client, serverPath, containerPath)
+		if err != nil {
+			return nil, fmt.Errorf("could not find container '%s': %w", containerPath, err)
+		}
+		startPath = resolvedPath
+		actualContainerName = resolvedName
+	}
+
+	tracks, err := client.GetAllServerTracks(startPath, progress)
+	if err != nil {
+		return nil, err
+	}
+
+	indexedTracks := make([]IndexedTrack, 0, len(tracks))
+	for _, track := range tracks {
+		it := IndexedTrack{
+			Title: track.Title,
+			Path:  track.Path,
+			Icon:  track.Icon,
+		}
+
+		// Extract metadata
+		if track.MediaData != nil {
+			it.Artist = track.MediaData.MetaData.Artist
+			it.Album = track.MediaData.MetaData.Album
+			if len(track.MediaData.Resources) > 0 {
+				it.Duration = track.MediaData.Resources[0].Duration
+			}
+		}
+
+		// Build pre-computed search field (lowercase for fast matching)
+		searchParts := []string{strings.ToLower(it.Title)}
+		if it.Artist != "" {
+			searchParts = append(searchParts, strings.ToLower(it.Artist))
+		}
+		if it.Album != "" {
+			searchParts = append(searchParts, strings.ToLower(it.Album))
+		}
+		it.SearchField = strings.Join(searchParts, " ")
+
+		indexedTracks = append(indexedTracks, it)
+	}
+
+	index := &TrackIndex{
+		ServerPath:    serverPath,
+		ServerName:    serverName,
+		ContainerPath: startPath,
+		ContainerName: actualContainerName,
+		Tracks:        indexedTracks,
+		IndexedAt:     time.Now(),
+		TrackCount:    len(indexedTracks),
+		IndexVersion:  trackIndexVersion,
+	}
+
+	return index, nil
+}
+
+// findContainerByPath navigates to a container by path like "Music/Hilli's Music/All Artists".
+// Each path component is matched case-insensitively.
+// If a component doesn't match exactly, it shows available options.
+func findContainerByPath(client *kefw2.AirableClient, serverPath, containerPath string) (string, string, error) {
+	// Split the path into components
+	parts := strings.Split(containerPath, "/")
+	// Remove empty parts (handles trailing slashes, etc.)
+	var cleanParts []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			cleanParts = append(cleanParts, p)
+		}
+	}
+
+	if len(cleanParts) == 0 {
+		return serverPath, "", nil
+	}
+
+	currentPath := serverPath
+	var resolvedParts []string
+
+	for i, part := range cleanParts {
+		resp, err := client.BrowseContainerAll(currentPath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to browse '%s': %w", strings.Join(resolvedParts, "/"), err)
+		}
+
+		partLower := strings.ToLower(part)
+		var found bool
+		var availableContainers []string
+
+		for _, item := range resp.Rows {
+			if item.Type == "container" {
+				availableContainers = append(availableContainers, item.Title)
+				if strings.ToLower(item.Title) == partLower {
+					currentPath = item.Path
+					resolvedParts = append(resolvedParts, item.Title)
+					found = true
+					break
+				}
+			}
+		}
+
+		if !found {
+			// Build helpful error message
+			pathSoFar := ""
+			if len(resolvedParts) > 0 {
+				pathSoFar = strings.Join(resolvedParts, "/") + "/"
+			}
+			return "", "", fmt.Errorf("container '%s' not found in '%s'\nAvailable: %s",
+				part, pathSoFar, strings.Join(availableContainers, ", "))
+		}
+
+		// Only continue if there are more parts
+		if i == len(cleanParts)-1 {
+			break
+		}
+	}
+
+	return currentPath, strings.Join(resolvedParts, "/"), nil
+}
+
+// listContainersAtPath returns the available containers at a given path (for tab completion).
+// containerPath can be empty (returns root containers) or a partial path like "Music/Hilli's Music".
+func listContainersAtPath(client *kefw2.AirableClient, serverPath, containerPath string) ([]string, error) {
+	// Navigate to the container path first
+	currentPath := serverPath
+	if containerPath != "" {
+		var err error
+		currentPath, _, err = findContainerByPath(client, serverPath, containerPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Browse the current path
+	resp, err := client.BrowseContainerAll(currentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var containers []string
+	for _, item := range resp.Rows {
+		if item.Type == "container" {
+			containers = append(containers, item.Title)
+		}
+	}
+
+	return containers, nil
+}
+
+// SearchTracks searches the track index with fuzzy matching.
+// Returns tracks where title, artist, or album matches the query.
+func SearchTracks(index *TrackIndex, query string, maxResults int) []IndexedTrack {
+	if index == nil || query == "" {
+		return nil
+	}
+
+	query = strings.ToLower(query)
+	queryParts := strings.Fields(query)
+
+	var results []IndexedTrack
+	for _, track := range index.Tracks {
+		// Check if all query parts match (AND logic)
+		allMatch := true
+		for _, part := range queryParts {
+			if !strings.Contains(track.SearchField, part) {
+				// Try fuzzy match as fallback
+				if !FuzzyMatch(track.SearchField, part) {
+					allMatch = false
+					break
+				}
+			}
+		}
+
+		if allMatch {
+			results = append(results, track)
+			if maxResults > 0 && len(results) >= maxResults {
+				break
+			}
+		}
+	}
+
+	return results
+}
+
+// IndexedTrackToContentItem converts an IndexedTrack back to a ContentItem for playback.
+func IndexedTrackToContentItem(track *IndexedTrack) kefw2.ContentItem {
+	item := kefw2.ContentItem{
+		Title: track.Title,
+		Type:  "audio",
+		Path:  track.Path,
+		Icon:  track.Icon,
+	}
+
+	if track.Artist != "" || track.Album != "" || track.Duration > 0 {
+		item.MediaData = &kefw2.MediaData{
+			MetaData: kefw2.MediaMetaData{
+				Artist:    track.Artist,
+				Album:     track.Album,
+				ServiceID: "UPnP",
+			},
+		}
+		if track.Duration > 0 {
+			item.MediaData.Resources = []kefw2.MediaResource{
+				{Duration: track.Duration},
+			}
+		}
+	}
+
+	return item
+}
+
+// FormatDuration formats a duration in milliseconds as mm:ss.
+func FormatDuration(ms int) string {
+	if ms <= 0 {
+		return ""
+	}
+	seconds := ms / 1000
+	minutes := seconds / 60
+	secs := seconds % 60
+	return fmt.Sprintf("%d:%02d", minutes, secs)
+}
+
+// GetTrackIndexStatus returns info about the current track index.
+func GetTrackIndexStatus() (exists bool, trackCount int, age time.Duration, serverName string) {
+	index, err := LoadTrackIndex()
+	if err != nil || index == nil {
+		return false, 0, 0, ""
+	}
+	return true, index.TrackCount, time.Since(index.IndexedAt), index.ServerName
+}

--- a/kefw2/airable.go
+++ b/kefw2/airable.go
@@ -49,6 +49,14 @@ func WithDiskCache() AirableClientOption {
 	}
 }
 
+// WithHTTPTimeout sets the HTTP client timeout for the Airable client.
+// Default is 10 seconds. Use longer timeouts for operations like indexing large libraries.
+func WithHTTPTimeout(timeout time.Duration) AirableClientOption {
+	return func(a *AirableClient) {
+		a.HTTPClient.Timeout = timeout
+	}
+}
+
 // ContentItem represents a content item from the Airable API.
 // Used across all services (radio, podcast, UPnP, Tidal).
 type ContentItem struct {


### PR DESCRIPTION
## Summary

This PR adds a local search index for UPnP media servers, enabling instant track searching across large music libraries.

### New Features

- **`upnp search [query]`** - Search tracks by title, artist, or album with ranked results
- **`upnp search`** (no query) - Browse full library with interactive filtering
- **`upnp index`** - View index status (track count, age, source container)
- **`upnp index --rebuild`** - Rebuild the search index
- **`upnp index --container "path"`** - Index from a specific folder
- **`config upnp index container`** - Set default container for indexing

### Search Features

- **Ranked scoring**: Exact matches score highest, word-boundary matches next
- **Multi-word queries**: All words must match, can be across different fields
  - Example: `upnp search public enemy uzi` finds "My Uzi Weighs a Ton" by "Public Enemy"
- **Word-boundary matching**: "beatles" matches "The Beatles" but not "Beastie Boys"

### Content Picker Improvements

- Filter now matches on **artist/album** in addition to title
- **Page Up/Page Down** navigation for faster scrolling

### Other Changes

- `upnp play` now recursively scans sub-containers (play all albums under an artist)
- Fixed `cache status` to show correct cache file and entry count

### Implementation

The index is stored in `~/.cache/kefw2/upnp_track_index.json` and includes:
- Pre-computed lowercase search fields for fast matching
- Container path, track count, and timestamp metadata
- Typical scan of ~9,500 tracks takes ~30 seconds