### PR TITLE
Fix: Store URI and MimeType in track index for playback

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,39 @@ jobs:
         with:
           go-version: '1.24'
           check-latest: true
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          # Strip 'v' prefix from tag to match CHANGELOG format
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Extracting release notes for version: $VERSION"
+          
+          # Extract section for this version (from ## [x.y.z] to next ## [ or EOF)
+          # Skip the first line (version header) since GitHub shows the tag separately
+          awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          
+          # Remove leading blank lines
+          sed -i '/./,$!d' /tmp/release-notes.md
+          
+          # Check if we found anything
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Warning: No changelog entry found for version $VERSION"
+            echo "See [CHANGELOG.md](https://github.com/hilli/go-kef-w2/blob/main/CHANGELOG.md) for details." > /tmp/release-notes.md
+          fi
+          
+          echo "--- Release notes ---"
+          cat /tmp/release-notes.md
+          echo "--- End release notes ---"
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean
+          args: release --clean --release-notes=/tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
           MASTODON_CLIENT_ID: ${{ secrets.MASTODON_CLIENT_ID }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -150,8 +150,4 @@ announce:
     server: https://mastodon.social
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-02-04
+
+### Fixed
+
+- Fixed playback from `upnp search` results - tracks now play and add to queue correctly
+  - The search index was missing audio file URIs required for playback
+  - Index version bumped to v2; run `kefw2 upnp index --rebuild` after updating
+
 ## [0.2.2] - 2025-02-03
 
 ### Added
@@ -358,7 +366,8 @@ Implemented by: `Source`, `SpeakerStatus`, `CableMode`
 
 7. **Update player ID field access**: If you access `playId.SystemMemberId`, change it to `playId.SystemMemberID`.
 
-[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/hilli/go-kef-w2/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/hilli/go-kef-w2/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/hilli/go-kef-w2/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/hilli/go-kef-w2/compare/v0.1.0...v0.2.0

--- a/cmd/kefw2/cmd/browser_styles.go
+++ b/cmd/kefw2/cmd/browser_styles.go
@@ -23,7 +23,7 @@ package cmd
 
 import "github.com/charmbracelet/lipgloss"
 
-// ServiceType represents the type of content service (radio, podcast, upnp)
+// ServiceType represents the type of content service (radio, podcast, upnp).
 type ServiceType string
 
 const (
@@ -32,14 +32,14 @@ const (
 	ServiceUPnP    ServiceType = "upnp"
 )
 
-// ServiceColors defines the color scheme for each service type
+// ServiceColors defines the color scheme for each service type.
 var ServiceColors = map[ServiceType]lipgloss.Color{
 	ServiceRadio:   lipgloss.Color("39"),  // Blue for radio
 	ServicePodcast: lipgloss.Color("207"), // Pink/magenta for podcast
 	ServiceUPnP:    lipgloss.Color("214"), // Orange for UPnP
 }
 
-// BrowserStyles holds styled renderers for the content browser TUI
+// BrowserStyles holds styled renderers for the content browser TUI.
 type BrowserStyles struct {
 	Title    lipgloss.Style
 	Search   lipgloss.Style
@@ -50,7 +50,7 @@ type BrowserStyles struct {
 	Dimmed   lipgloss.Style
 }
 
-// NewBrowserStyles creates a new set of browser styles for the given service type
+// NewBrowserStyles creates a new set of browser styles for the given service type.
 func NewBrowserStyles(service ServiceType) BrowserStyles {
 	color := ServiceColors[service]
 	if color == "" {
@@ -87,11 +87,11 @@ func NewBrowserStyles(service ServiceType) BrowserStyles {
 	}
 }
 
-// Common styles used across all services
+// Common styles used across all services.
 var (
-	// containerSuffix is shown after container names
+	// containerSuffix is shown after container names.
 	containerSuffix = "/"
 
-	// maxVisibleItems is the number of items visible in the picker at once
+	// maxVisibleItems is the number of items visible in the picker at once.
 	maxVisibleItems = 15
 )

--- a/cmd/kefw2/cmd/cache.go
+++ b/cmd/kefw2/cmd/cache.go
@@ -33,7 +33,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CachedItem represents a cached content item for completion
+// CachedItem represents a cached content item for completion.
 type CachedItem struct {
 	Title       string `json:"title"`
 	Path        string `json:"path"`         // Actual API path
@@ -42,13 +42,13 @@ type CachedItem struct {
 	Description string `json:"description"`  // Optional description
 }
 
-// CacheEntry represents a cached response for a browse path
+// CacheEntry represents a cached response for a browse path.
 type CacheEntry struct {
 	Items     []CachedItem `json:"items"`
 	FetchedAt time.Time    `json:"fetched_at"`
 }
 
-// BrowseCache provides caching for hierarchical path completion
+// BrowseCache provides caching for hierarchical path completion.
 type BrowseCache struct {
 	cacheDir string
 	entries  map[string]*CacheEntry
@@ -56,10 +56,10 @@ type BrowseCache struct {
 	dirty    bool // Track if cache needs saving
 }
 
-// Global cache instance
+// Global cache instance.
 var browseCache *BrowseCache
 
-// NewBrowseCache creates a new browse cache
+// NewBrowseCache creates a new browse cache.
 func NewBrowseCache() (*BrowseCache, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
@@ -69,7 +69,7 @@ func NewBrowseCache() (*BrowseCache, error) {
 	cacheDir = filepath.Join(cacheDir, "kefw2")
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
@@ -84,7 +84,7 @@ func NewBrowseCache() (*BrowseCache, error) {
 	return cache, nil
 }
 
-// InitCache initializes the global browse cache
+// InitCache initializes the global browse cache.
 func InitCache() {
 	var err error
 	browseCache, err = NewBrowseCache()
@@ -97,18 +97,18 @@ func InitCache() {
 	}
 }
 
-// cacheFilePath returns the path to the cache file
+// cacheFilePath returns the path to the cache file.
 func (c *BrowseCache) cacheFilePath() string {
 	return filepath.Join(c.cacheDir, "browse_cache.json")
 }
 
-// IsEnabled returns whether caching is enabled
+// IsEnabled returns whether caching is enabled.
 func (c *BrowseCache) IsEnabled() bool {
 	return viper.GetBool("cache.enabled")
 }
 
-// GetTTL returns the TTL for a given service type
-// Defaults are set in root.go initConfig(): default=300, radio=300, podcast=300, upnp=60
+// GetTTL returns the TTL for a given service type.
+// Defaults are set in root.go initConfig(): default=300, radio=300, podcast=300, upnp=60.
 func (c *BrowseCache) GetTTL(service string) time.Duration {
 	key := fmt.Sprintf("cache.ttl_%s", service)
 	seconds := viper.GetInt(key)
@@ -122,7 +122,7 @@ func (c *BrowseCache) GetTTL(service string) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
-// Get retrieves items from cache if valid
+// Get retrieves items from cache if valid.
 func (c *BrowseCache) Get(path string, service string) ([]CachedItem, bool) {
 	if !c.IsEnabled() {
 		return nil, false
@@ -146,7 +146,7 @@ func (c *BrowseCache) Get(path string, service string) ([]CachedItem, bool) {
 	return entry.Items, true
 }
 
-// Set stores items in cache
+// Set stores items in cache.
 func (c *BrowseCache) Set(path string, service string, items []CachedItem) {
 	if !c.IsEnabled() {
 		return
@@ -163,7 +163,7 @@ func (c *BrowseCache) Set(path string, service string, items []CachedItem) {
 	c.dirty = true
 }
 
-// Clear removes all cached data
+// Clear removes all cached data.
 func (c *BrowseCache) Clear() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -175,7 +175,7 @@ func (c *BrowseCache) Clear() error {
 	return os.Remove(c.cacheFilePath())
 }
 
-// Status returns cache statistics
+// Status returns cache statistics.
 func (c *BrowseCache) Status() (entries int, size int64, oldestAge time.Duration) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -201,7 +201,7 @@ func (c *BrowseCache) Status() (entries int, size int64, oldestAge time.Duration
 	return
 }
 
-// Load loads cache from disk
+// Load loads cache from disk.
 func (c *BrowseCache) Load() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -223,7 +223,7 @@ func (c *BrowseCache) Load() error {
 	return nil
 }
 
-// Save persists cache to disk
+// Save persists cache to disk.
 func (c *BrowseCache) Save() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -246,7 +246,7 @@ func (c *BrowseCache) Save() error {
 		return err
 	}
 
-	if err := os.WriteFile(c.cacheFilePath(), data, 0644); err != nil {
+	if err := os.WriteFile(c.cacheFilePath(), data, 0600); err != nil {
 		return err
 	}
 
@@ -254,12 +254,12 @@ func (c *BrowseCache) Save() error {
 	return nil
 }
 
-// CacheDir returns the cache directory path
+// CacheDir returns the cache directory path.
 func (c *BrowseCache) CacheDir() string {
 	return c.cacheDir
 }
 
-// FindItemByTitle finds a cached item by its title within a parent path
+// FindItemByTitle finds a cached item by its title within a parent path.
 func (c *BrowseCache) FindItemByTitle(parentPath, service, title string) (*CachedItem, bool) {
 	items, ok := c.Get(parentPath, service)
 	if !ok {
@@ -274,8 +274,8 @@ func (c *BrowseCache) FindItemByTitle(parentPath, service, title string) (*Cache
 	return nil, false
 }
 
-// ResolveDisplayPath resolves a display path (title-based) to an API path
-// Returns the API path and the last item, or empty string if not found
+// ResolveDisplayPath resolves a display path (title-based) to an API path.
+// Returns the API path and the last item, or empty string if not found.
 func (c *BrowseCache) ResolveDisplayPath(displayPath, service string) (string, *CachedItem, bool) {
 	if displayPath == "" {
 		return "", nil, true // Empty path = top level, no API path needed
@@ -318,7 +318,7 @@ func (c *BrowseCache) ResolveDisplayPath(displayPath, service string) (string, *
 // Cache Command
 // ============================================
 
-// cacheCmd represents the cache command
+// cacheCmd represents the cache command.
 var cacheCmd = &cobra.Command{
 	Use:   "cache",
 	Short: "Manage browse cache for tab completion",
@@ -328,11 +328,11 @@ The cache stores browse results to speed up tab completion.
 Cache location: ~/.cache/kefw2/`,
 }
 
-// cacheClearCmd clears the cache
+// cacheClearCmd clears the cache.
 var cacheClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Clear all cached browse data",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if browseCache == nil {
 			errorPrinter.Println("Cache not initialized")
 			return
@@ -345,11 +345,11 @@ var cacheClearCmd = &cobra.Command{
 	},
 }
 
-// cacheStatusCmd shows cache status
+// cacheStatusCmd shows cache status.
 var cacheStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show cache statistics",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		// Get cache directory
 		cacheDir, err := os.UserCacheDir()
 		if err != nil {
@@ -361,7 +361,7 @@ var cacheStatusCmd = &cobra.Command{
 		rowsCachePath := filepath.Join(cacheDir, "rows_cache.json")
 		if info, err := os.Stat(rowsCachePath); err == nil {
 			// Read and parse the cache file to count entries
-			data, readErr := os.ReadFile(rowsCachePath)
+			data, readErr := os.ReadFile(rowsCachePath) //nolint:gosec // Path is constructed from user's cache dir
 			var entryCount int
 			var oldestAge time.Duration
 			if readErr == nil {
@@ -422,7 +422,7 @@ var cacheStatusCmd = &cobra.Command{
 	},
 }
 
-// formatBytes formats bytes as human-readable string
+// formatBytes formats bytes as human-readable string.
 func formatBytes(bytes int64) string {
 	const unit = 1024
 	if bytes < unit {

--- a/cmd/kefw2/cmd/completion_helpers.go
+++ b/cmd/kefw2/cmd/completion_helpers.go
@@ -47,16 +47,16 @@ import (
 //   Names containing "/" are escaped as "%2F"
 //   Example: "AC/DC" becomes "AC%2FDC" in paths
 
-// EscapePathSegment escapes special characters for use in hierarchical paths
-// "/" -> "%2F" (path separator)
-// ":" -> "%3A" (zsh word separator)
+// EscapePathSegment escapes special characters for use in hierarchical paths.
+// "/" -> "%2F" (path separator).
+// ":" -> "%3A" (zsh word separator).
 func EscapePathSegment(s string) string {
 	s = strings.ReplaceAll(s, "/", "%2F")
 	s = strings.ReplaceAll(s, ":", "%3A")
 	return s
 }
 
-// UnescapePathSegment unescapes special characters back to original
+// UnescapePathSegment unescapes special characters back to original.
 func UnescapePathSegment(s string) string {
 	s = strings.ReplaceAll(s, "%2F", "/")
 	s = strings.ReplaceAll(s, "%3A", ":")
@@ -86,7 +86,7 @@ func ParseHierarchicalPath(path string) []string {
 	return result
 }
 
-// BuildHierarchicalPath joins segments with "/", escaping slashes in names
+// BuildHierarchicalPath joins segments with "/", escaping slashes in names.
 func BuildHierarchicalPath(segments []string) string {
 	escaped := make([]string, len(segments))
 	for i, seg := range segments {
@@ -97,7 +97,7 @@ func BuildHierarchicalPath(segments []string) string {
 
 // FuzzyMatch checks if all characters in pattern appear in str in order.
 // Both strings are compared case-insensitively.
-// Example: FuzzyMatch("WDVX Radio", "wdx") returns true
+// Example: FuzzyMatch("WDVX Radio", "wdx") returns true.
 func FuzzyMatch(str, pattern string) bool {
 	str = strings.ToLower(str)
 	pattern = strings.ToLower(pattern)
@@ -114,8 +114,8 @@ func FuzzyMatch(str, pattern string) bool {
 // Radio Browse Completion
 // ============================================
 
-// HierarchicalRadioCompletion provides tab completion for radio browse paths
-func HierarchicalRadioCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// HierarchicalRadioCompletion provides tab completion for radio browse paths.
+func HierarchicalRadioCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Don't complete if we already have an argument
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -189,14 +189,14 @@ func HierarchicalRadioCompletion(cmd *cobra.Command, args []string, toComplete s
 	return buildRadioCompletions(items, parentPath), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }
 
-// convertRowsToCachedItems converts API rows to cached items for completion
-// parentDisplayPath is the display path of the parent (for building full display paths)
+// convertRowsToCachedItems converts API rows to cached items for completion.
+// parentDisplayPath is the display path of the parent (for building full display paths).
 func convertRowsToCachedItems(rows []kefw2.ContentItem, parentDisplayPath string) []CachedItem {
 	items := make([]CachedItem, 0, len(rows))
 	for _, row := range rows {
 		itemType := "playable"
-		if row.Type == "container" && !row.ContainerPlayable {
-			itemType = "container"
+		if row.Type == TypeContainer && !row.ContainerPlayable {
+			itemType = TypeContainer
 		}
 
 		// Build the display path for this item
@@ -216,9 +216,9 @@ func convertRowsToCachedItems(rows []kefw2.ContentItem, parentDisplayPath string
 	return items
 }
 
-// buildRadioCompletions builds completion strings from cached items
-// Returns full paths (required for shell to replace the argument correctly)
-// Uses Cobra's "completion\tdescription" format for cleaner display
+// buildRadioCompletions builds completion strings from cached items.
+// Returns full paths (required for shell to replace the argument correctly).
+// Uses Cobra's "completion\tdescription" format for cleaner display.
 func buildRadioCompletions(items []CachedItem, currentPath string) []string {
 	completions := make([]string, 0, len(items))
 
@@ -233,14 +233,14 @@ func buildRadioCompletions(items []CachedItem, currentPath string) []string {
 		fullPath := prefix + escapedTitle
 
 		// Add "/" suffix for containers to hint "more inside"
-		if item.Type == "container" {
+		if item.Type == TypeContainer {
 			fullPath += "/"
 		}
 
 		// Use tab-separated format: "completion\tdescription"
 		// The description shows just the name, making the display cleaner
 		completion := fullPath + "\t" + item.Title
-		if item.Type == "container" {
+		if item.Type == TypeContainer {
 			completion = fullPath + "\t" + item.Title + "/"
 		}
 
@@ -254,7 +254,7 @@ func buildRadioCompletions(items []CachedItem, currentPath string) []string {
 // Utility Functions for Completion
 // ============================================
 
-// FilterItemsByPrefix returns items whose title starts with the given prefix
+// FilterItemsByPrefix returns items whose title starts with the given prefix.
 func FilterItemsByPrefix(items []CachedItem, prefix string) []CachedItem {
 	if prefix == "" {
 		return items
@@ -274,7 +274,7 @@ func FilterItemsByPrefix(items []CachedItem, prefix string) []CachedItem {
 // Podcast Browse Completion
 // ============================================
 
-// PodcastBrowseCategories is the list of available browse categories
+// PodcastBrowseCategories is the list of available browse categories.
 var PodcastBrowseCategories = []string{
 	"popular\tPopular podcasts",
 	"trending\tTrending podcasts",
@@ -282,8 +282,8 @@ var PodcastBrowseCategories = []string{
 	"favorites\tYour favorite podcasts",
 }
 
-// PodcastBrowseCompletion provides tab completion for podcast browse categories
-func PodcastBrowseCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// PodcastBrowseCompletion provides tab completion for podcast browse categories.
+func PodcastBrowseCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Don't complete if we already have an argument
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -311,7 +311,7 @@ func PodcastBrowseCompletion(cmd *cobra.Command, args []string, toComplete strin
 // Radio Station Completion Functions
 // ============================================
 
-// Radio completion functions using MakeStationCompletion factory
+// Radio completion functions using MakeStationCompletion factory.
 var (
 	RadioLocalCompletion     = MakeStationCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetRadioLocalAll() })
 	RadioFavoritesCompletion = MakeStationCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetRadioFavoritesAll() })
@@ -321,8 +321,8 @@ var (
 	RadioPopularCompletion   = MakeStationCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetRadioPopularAll() })
 )
 
-// DynamicRadioSearchCompletion provides dynamic completion for radio search by querying the API
-func DynamicRadioSearchCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// DynamicRadioSearchCompletion provides dynamic completion for radio search by querying the API.
+func DynamicRadioSearchCompletion(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Need at least 2 characters to search
 	if len(toComplete) < 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -341,7 +341,7 @@ func DynamicRadioSearchCompletion(cmd *cobra.Command, args []string, toComplete 
 	return buildStationCompletions(resp.Rows, ""), cobra.ShellCompDirectiveNoFileComp
 }
 
-// buildStationCompletions builds completion strings from radio station rows
+// buildStationCompletions builds completion strings from radio station rows.
 func buildStationCompletions(rows []kefw2.ContentItem, filter string) []string {
 	completions := make([]string, 0, len(rows))
 	lowerFilter := strings.ToLower(filter)
@@ -377,16 +377,16 @@ func buildStationCompletions(rows []kefw2.ContentItem, filter string) []string {
 	return completions
 }
 
-// isPlayableStation checks if a content item is a playable radio station
+// isPlayableStation checks if a content item is a playable radio station.
 func isPlayableStation(item kefw2.ContentItem) bool {
-	return (item.ContainerPlayable && item.AudioType == "audioBroadcast") || item.Type == "audio"
+	return (item.ContainerPlayable && item.AudioType == TypeAudioBroadcast) || item.Type == TypeAudio
 }
 
 // ============================================
 // Podcast Completion Functions
 // ============================================
 
-// Podcast completion functions using MakePodcastCompletion factory
+// Podcast completion functions using MakePodcastCompletion factory.
 var (
 	PodcastPopularCompletion   = MakePodcastCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetPodcastPopularAll() })
 	PodcastTrendingCompletion  = MakePodcastCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetPodcastTrendingAll() })
@@ -394,8 +394,8 @@ var (
 	PodcastFavoritesCompletion = MakePodcastCompletion(func(c *kefw2.AirableClient) (*kefw2.RowsResponse, error) { return c.GetPodcastFavoritesAll() })
 )
 
-// DynamicPodcastSearchCompletion provides dynamic completion for podcast search
-func DynamicPodcastSearchCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// DynamicPodcastSearchCompletion provides dynamic completion for podcast search.
+func DynamicPodcastSearchCompletion(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Need at least 2 characters to search
 	if len(toComplete) < 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -416,7 +416,7 @@ func DynamicPodcastSearchCompletion(cmd *cobra.Command, args []string, toComplet
 
 // PodcastPlayCompletion provides completion for podcast play command.
 // Shows favorites when empty, searches when 2+ characters typed, shows episodes after "ShowName/".
-func PodcastPlayCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func PodcastPlayCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -495,8 +495,8 @@ func PodcastPlayCompletion(cmd *cobra.Command, args []string, toComplete string)
 	return buildPodcastCompletions(resp.Rows, toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }
 
-// PodcastFilterCompletion provides hierarchical completion for podcast filter paths
-func PodcastFilterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// PodcastFilterCompletion provides hierarchical completion for podcast filter paths.
+func PodcastFilterCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -547,8 +547,8 @@ func PodcastFilterCompletion(cmd *cobra.Command, args []string, toComplete strin
 }
 
 // buildPodcastCompletionsWithEpisodes handles two-level completion:
-// 1. At top level, shows podcast names with "/" suffix
-// 2. After "ShowName/", shows episodes of that show
+// 1. At top level, shows podcast names with "/" suffix.
+// 2. After "ShowName/", shows episodes of that show.
 func buildPodcastCompletionsWithEpisodes(client *kefw2.AirableClient, fetchPodcasts func() (*kefw2.RowsResponse, error), toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Check if we're completing an episode (path contains "/")
 	if strings.Contains(toComplete, "/") {
@@ -598,14 +598,14 @@ func buildPodcastCompletionsWithEpisodes(client *kefw2.AirableClient, fetchPodca
 	return buildPodcastCompletions(resp.Rows, toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }
 
-// buildPodcastCompletions builds completion strings from podcast container rows
+// buildPodcastCompletions builds completion strings from podcast container rows.
 func buildPodcastCompletions(rows []kefw2.ContentItem, filter string) []string {
 	completions := make([]string, 0, len(rows))
 	lowerFilter := strings.ToLower(filter)
 
 	for _, row := range rows {
 		// Only include podcast containers
-		if row.Type != "container" {
+		if row.Type != TypeContainer {
 			continue
 		}
 
@@ -619,10 +619,6 @@ func buildPodcastCompletions(rows []kefw2.ContentItem, filter string) []string {
 		fullPath := escapedTitle + "/"
 
 		// Use tab-separated format: "completion\tdescription"
-		description := row.LongDescription
-		if description == "" {
-			description = "Podcast"
-		}
 		completions = append(completions, fullPath+"\t"+row.Title)
 
 		// Limit suggestions for shell UX
@@ -634,7 +630,7 @@ func buildPodcastCompletions(rows []kefw2.ContentItem, filter string) []string {
 	return completions
 }
 
-// buildEpisodeCompletions builds completion strings for podcast episodes
+// buildEpisodeCompletions builds completion strings for podcast episodes.
 func buildEpisodeCompletions(rows []kefw2.ContentItem, showName string, filter string) []string {
 	completions := make([]string, 0, len(rows))
 	// Unescape the filter since it may contain %3A for ":"
@@ -670,7 +666,7 @@ func buildEpisodeCompletions(rows []kefw2.ContentItem, showName string, filter s
 
 // HierarchicalUPnPCompletion provides tab completion for UPnP browse/play paths.
 // Uses default server from config. If no default server, shows server list at top level.
-func HierarchicalUPnPCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func HierarchicalUPnPCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -738,13 +734,13 @@ func HierarchicalUPnPCompletion(cmd *cobra.Command, args []string, toComplete st
 func convertUPnPRowsToCachedItems(rows []kefw2.ContentItem, parentDisplayPath string) []CachedItem {
 	items := make([]CachedItem, 0, len(rows))
 	for _, row := range rows {
-		if row.Type == "query" {
+		if row.Type == TypeQuery {
 			continue // Skip search entries
 		}
 
 		itemType := "playable"
-		if row.Type == "container" {
-			itemType = "container"
+		if row.Type == TypeContainer {
+			itemType = TypeContainer
 		}
 
 		displayPath := EscapePathSegment(row.Title)
@@ -781,12 +777,12 @@ func buildUPnPCompletions(items []CachedItem, currentPath string) []string {
 		escapedTitle := EscapePathSegment(item.Title)
 		fullPath := prefix + escapedTitle
 
-		if item.Type == "container" {
+		if item.Type == TypeContainer {
 			fullPath += "/"
 		}
 
 		completion := fullPath + "\t" + item.Title
-		if item.Type == "container" {
+		if item.Type == TypeContainer {
 			completion = fullPath + "\t" + item.Title + "/"
 		}
 
@@ -802,7 +798,7 @@ func buildUPnPCompletions(items []CachedItem, currentPath string) []string {
 
 // QueueItemCompletion provides tab completion for queue items.
 // Format: "Title - Artist" with "(2)", "(3)" for duplicates.
-func QueueItemCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func QueueItemCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -869,10 +865,10 @@ func buildQueueCompletions(rows []kefw2.ContentItem, filter string) []string {
 }
 
 // QueueMoveCompletion provides tab completion for the queue move command.
-// First arg: track to move (by title or position)
-// Second arg: destination keywords or track title
-// Third arg: target track (only for before/after)
-func QueueMoveCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// First arg: track to move (by title or position).
+// Second arg: destination keywords or track title.
+// Third arg: target track (only for before/after).
+func QueueMoveCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if currentSpeaker == nil || currentSpeaker.IPAddress == "" {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/kefw2/cmd/config_cache.go
+++ b/cmd/kefw2/cmd/config_cache.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// configCacheCmd configures cache settings
+// configCacheCmd configures cache settings.
 var configCacheCmd = &cobra.Command{
 	Use:   "cache [setting] [value]",
 	Short: "Show or configure cache settings",
@@ -51,7 +51,7 @@ Examples:
   kefw2 config cache enable             # Enable caching
   kefw2 config cache ttl-radio 600      # Set radio cache TTL to 10 minutes`,
 	Args: cobra.MaximumNArgs(2),
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			// Complete setting names
 			completions := []string{
@@ -67,7 +67,7 @@ Examples:
 		// No completion for values (user enters a number)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// No args: show all cache settings
 		if len(args) == 0 {
 			showAllCacheSettings()
@@ -123,7 +123,7 @@ Examples:
 	},
 }
 
-// showAllCacheSettings displays all current cache configuration values
+// showAllCacheSettings displays all current cache configuration values.
 func showAllCacheSettings() {
 	headerPrinter.Println("Cache Configuration:")
 

--- a/cmd/kefw2/cmd/config_upnp.go
+++ b/cmd/kefw2/cmd/config_upnp.go
@@ -30,27 +30,27 @@ import (
 	"github.com/hilli/go-kef-w2/kefw2"
 )
 
-// upnpConfigCmd is the parent for UPnP config subcommands
+// upnpConfigCmd is the parent for UPnP config subcommands.
 var upnpConfigCmd = &cobra.Command{
 	Use:   "upnp",
 	Short: "Configure UPnP/DLNA settings",
 	Long:  `Configure UPnP/DLNA media server settings.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
 	},
 }
 
-// upnpServerConfigCmd is the parent for server config subcommands
+// upnpServerConfigCmd is the parent for server config subcommands.
 var upnpServerConfigCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Configure default UPnP media server",
 	Long:  `Configure the default UPnP media server for browsing and playback.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
 	},
 }
 
-// upnpServerDefaultCmd shows or sets the default server
+// upnpServerDefaultCmd shows or sets the default server.
 var upnpServerDefaultCmd = &cobra.Command{
 	Use:   "default [server-name]",
 	Short: "Show or set the default UPnP media server",
@@ -62,7 +62,7 @@ With a server name, sets that server as the default.
 Examples:
   kefw2 config upnp server default                           # Show current
   kefw2 config upnp server default "Plex Media Server: srv"  # Set default`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			// Show current default
 			serverName := viper.GetString("upnp.default_server")
@@ -95,12 +95,12 @@ Examples:
 	ValidArgsFunction: UPnPServerCompletion,
 }
 
-// upnpServerListCmd lists available servers
+// upnpServerListCmd lists available servers.
 var upnpServerListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List available UPnP media servers",
 	Long:  `List all UPnP/DLNA media servers available on the network.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		resp, err := client.GetMediaServers()
@@ -110,7 +110,7 @@ var upnpServerListCmd = &cobra.Command{
 
 		headerPrinter.Println("Available UPnP servers:")
 		for _, item := range resp.Rows {
-			if item.Type == "query" {
+			if item.Type == TypeQuery {
 				continue // Skip "Search" entry
 			}
 			if item.Title == defaultServer {
@@ -123,8 +123,8 @@ var upnpServerListCmd = &cobra.Command{
 	ValidArgsFunction: cobra.NoFileCompletions,
 }
 
-// UPnPServerCompletion provides tab completion for UPnP server names
-func UPnPServerCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// UPnPServerCompletion provides tab completion for UPnP server names.
+func UPnPServerCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -152,17 +152,17 @@ func UPnPServerCompletion(cmd *cobra.Command, args []string, toComplete string) 
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// upnpIndexConfigCmd is the parent for index config subcommands
+// upnpIndexConfigCmd is the parent for index config subcommands.
 var upnpIndexConfigCmd = &cobra.Command{
 	Use:   "index",
 	Short: "Configure UPnP search index settings",
 	Long:  `Configure settings for the UPnP search index, including the container path to index.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
 	},
 }
 
-// upnpIndexContainerCmd shows or sets the index container path
+// upnpIndexContainerCmd shows or sets the index container path.
 var upnpIndexContainerCmd = &cobra.Command{
 	Use:   "container [path]",
 	Short: "Show or set the container path for indexing",
@@ -179,7 +179,7 @@ Examples:
   kefw2 config upnp index container "Music"                          # Index Music folder
   kefw2 config upnp index container "Music/Hilli's Music/By Folder"  # Index specific folder
   kefw2 config upnp index container ""                               # Clear (index entire server)`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			// Show current setting
 			containerPath := viper.GetString("upnp.index_container")
@@ -227,8 +227,8 @@ Examples:
 	ValidArgsFunction: UPnPContainerCompletion,
 }
 
-// UPnPContainerCompletion provides tab completion for container paths
-func UPnPContainerCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// UPnPContainerCompletion provides tab completion for container paths.
+func UPnPContainerCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/kefw2/cmd/constants.go
+++ b/cmd/kefw2/cmd/constants.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2025 Jens Hilligsøe <jens@hilli.dk>
+Licensed under the MIT License
+*/
+package cmd
+
+// Content type constants used across the codebase.
+const (
+	TypeAudio          = "audio"
+	TypeContainer      = "container"
+	TypeAudioBroadcast = "audioBroadcast"
+	TypeQuery          = "query"
+	TypeEpisodes       = "episodes"
+)
+
+// Key binding constants for TUI navigation.
+const (
+	KeyCtrlC = "ctrl+c"
+	KeyEnter = "enter"
+	KeyEsc   = "esc"
+)
+
+// Mode constants for browser states.
+const (
+	ModeFavorites = "favorites"
+	ModePopular   = "popular"
+	ModeTrending  = "trending"
+)
+
+// Playback mode constants.
+const (
+	PlayModeOff = "off"
+)
+
+// Title suffix constants for action modes.
+const (
+	SuffixRemoveMode = " (remove mode)"
+	SuffixSaveMode   = " (save mode)"
+	SuffixQueueMode  = " (queue mode)"
+)

--- a/cmd/kefw2/cmd/content_picker.go
+++ b/cmd/kefw2/cmd/content_picker.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hilli/go-kef-w2/kefw2"
 )
 
-// ContentAction represents the action to take on a selected item
+// ContentAction represents the action to take on a selected item.
 type ContentAction int
 
 const (
@@ -76,14 +76,14 @@ type ContentPickerCallbacks struct {
 
 // ContentPickerResult represents the outcome of running the content picker.
 type ContentPickerResult struct {
-	Selected  *kefw2.ContentItem
-	Action    ContentAction
-	Played    bool
-	Saved     bool
-	Removed   bool
-	Queued    bool
-	Cancelled bool
-	Error     error
+	Selected *kefw2.ContentItem
+	Action   ContentAction
+	Played   bool
+	Saved    bool
+	Removed  bool
+	Queued   bool
+	Canceled bool
+	Error    error
 }
 
 // ContentPickerModel is a unified picker for browsing content from any service.
@@ -200,7 +200,7 @@ func (m ContentPickerModel) isItemPlayable(item *kefw2.ContentItem) bool {
 		return m.callbacks.IsPlayable(item)
 	}
 	// Default: containers that aren't playable are navigable
-	return item.Type != "container" || item.ContainerPlayable
+	return item.Type != TypeContainer || item.ContainerPlayable
 }
 
 // Update implements tea.Model.
@@ -538,14 +538,14 @@ func (m ContentPickerModel) View() string {
 // Result returns the picker result after the program has exited.
 func (m ContentPickerModel) Result() ContentPickerResult {
 	return ContentPickerResult{
-		Selected:  m.selected,
-		Action:    m.action,
-		Played:    m.played,
-		Saved:     m.saved,
-		Removed:   m.removed,
-		Queued:    m.queued,
-		Cancelled: m.quitting && m.selected == nil,
-		Error:     m.err,
+		Selected: m.selected,
+		Action:   m.action,
+		Played:   m.played,
+		Saved:    m.saved,
+		Removed:  m.removed,
+		Queued:   m.queued,
+		Canceled: m.quitting && m.selected == nil,
+		Error:    m.err,
 	}
 }
 
@@ -573,7 +573,7 @@ func DefaultRadioCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks {
 			return client.RemoveRadioFavorite(item)
 		},
 		IsPlayable: func(item *kefw2.ContentItem) bool {
-			return item.Type != "container" || item.ContainerPlayable
+			return item.Type != TypeContainer || item.ContainerPlayable
 		},
 	}
 }
@@ -607,7 +607,7 @@ func DefaultPodcastCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks
 		},
 		IsPlayable: func(item *kefw2.ContentItem) bool {
 			// Only actual audio episodes are playable; all containers should be navigable
-			return item.Type == "audio"
+			return item.Type == TypeAudio
 		},
 	}
 }
@@ -654,7 +654,7 @@ func DefaultUPnPCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks {
 			// For UPnP, only audio tracks are directly playable.
 			// Containers (artists, albums, folders) should always be navigable,
 			// even if ContainerPlayable is true.
-			return item.Type == "audio"
+			return item.Type == TypeAudio
 		},
 	}
 }

--- a/cmd/kefw2/cmd/mute.go
+++ b/cmd/kefw2/cmd/mute.go
@@ -70,7 +70,7 @@ func parseMuteArg(mute string) (bool, error) {
 	switch mute {
 	case "on", "true", "1", "muted":
 		return true, nil
-	case "off", "false", "0", "unmute", "unmuted":
+	case PlayModeOff, "false", "0", "unmute", "unmuted":
 		return false, nil
 	default:
 		return false, fmt.Errorf("mute must be one of: on, off, true, false, 0, 1, muted, unmute, unmuted")

--- a/cmd/kefw2/cmd/queue.go
+++ b/cmd/kefw2/cmd/queue.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hilli/go-kef-w2/kefw2"
 )
 
-// queueCmd represents the queue command
+// queueCmd represents the queue command.
 var queueCmd = &cobra.Command{
 	Use:     "queue",
 	Aliases: []string{"q"},
@@ -43,9 +43,9 @@ Without subcommands, shows an interactive picker of queue items.
 Keyboard shortcuts in picker:
   Enter     - Play selected track
   Ctrl+d    - Delete selected track
-  Ctrl+x    - Clear entire queue
-  Esc       - Quit`,
-	Run: func(cmd *cobra.Command, args []string) {
+   Ctrl+x    - Clear entire queue
+   Esc       - Quit`,
+	Run: func(_ *cobra.Command, _ []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		resp, err := client.GetPlayQueue()
@@ -75,7 +75,7 @@ Keyboard shortcuts in picker:
 	},
 }
 
-// DefaultQueueCallbacks returns callbacks for queue playback
+// DefaultQueueCallbacks returns callbacks for queue playback.
 func DefaultQueueCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks {
 	return ContentPickerCallbacks{
 		Play: func(item *kefw2.ContentItem) error {
@@ -94,7 +94,7 @@ func DefaultQueueCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks {
 		},
 		Navigate: nil, // Queue items are not navigable
 		IsPlayable: func(item *kefw2.ContentItem) bool {
-			return item.Type == "audio"
+			return item.Type == TypeAudio
 		},
 		DeleteFromQueue: func(item *kefw2.ContentItem) error {
 			// Find the index of this item in the queue and remove it
@@ -115,13 +115,13 @@ func DefaultQueueCallbacks(client *kefw2.AirableClient) ContentPickerCallbacks {
 	}
 }
 
-// queueListCmd lists queue items non-interactively
+// queueListCmd lists queue items non-interactively.
 var queueListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls", "show"},
 	Short:   "List queue items",
 	Long:    `List all tracks in the current play queue without an interactive picker.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		resp, err := client.GetPlayQueue()
@@ -143,12 +143,12 @@ var queueListCmd = &cobra.Command{
 	},
 }
 
-// queueClearCmd clears the queue
+// queueClearCmd clears the queue.
 var queueClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Clear the play queue",
 	Long:  `Remove all tracks from the play queue.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		err := client.ClearPlaylist()
@@ -158,7 +158,7 @@ var queueClearCmd = &cobra.Command{
 	},
 }
 
-// queueRemoveCmd removes item(s) from the queue
+// queueRemoveCmd removes item(s) from the queue.
 var queueRemoveCmd = &cobra.Command{
 	Use:   "remove <track>",
 	Short: "Remove a track from the queue",
@@ -170,7 +170,7 @@ Examples:
   kefw2 queue remove "Yesterday - The Beatles"  # Remove by title - artist`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: QueueItemCompletion,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		resp, err := client.GetPlayQueue()
@@ -210,8 +210,8 @@ Examples:
 	},
 }
 
-// findQueueItemByLabel finds a queue item by "Title - Artist" label or just title
-// Returns the index (0-based) or -1 if not found
+// findQueueItemByLabel finds a queue item by "Title - Artist" label or just title.
+// Returns the index (0-based) or -1 if not found.
 func findQueueItemByLabel(items []kefw2.ContentItem, label string) int {
 	// Build labels with duplicate handling
 	labelMap := buildQueueLabelMap(items)
@@ -234,14 +234,14 @@ func findQueueItemByLabel(items []kefw2.ContentItem, label string) int {
 	return -1
 }
 
-// queueLabelEntry represents a queue item with its display label
+// queueLabelEntry represents a queue item with its display label.
 type queueLabelEntry struct {
 	Label string
 	Index int
 }
 
-// buildQueueLabelMap builds unique labels for queue items
-// Format: "Title - Artist" with "(2)", "(3)" etc. for duplicates
+// buildQueueLabelMap builds unique labels for queue items.
+// Format: "Title - Artist" with "(2)", "(3)" etc. for duplicates.
 func buildQueueLabelMap(items []kefw2.ContentItem) []queueLabelEntry {
 	entries := make([]queueLabelEntry, len(items))
 	labelCounts := make(map[string]int)
@@ -267,7 +267,7 @@ func buildQueueLabelMap(items []kefw2.ContentItem) []queueLabelEntry {
 	return entries
 }
 
-// queueMoveCmd moves an item in the queue
+// queueMoveCmd moves an item in the queue.
 var queueMoveCmd = &cobra.Command{
 	Use:   "move <track> <destination> [target-track]",
 	Short: "Move a track within the queue",
@@ -298,7 +298,7 @@ Examples:
   kefw2 queue move "Yesterday" after "Help"   # Move after another track`,
 	Args:              cobra.RangeArgs(2, 3),
 	ValidArgsFunction: QueueMoveCompletion,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		// Get queue first
@@ -318,7 +318,7 @@ Examples:
 		}
 
 		// Parse the destination (second argument, and optionally third)
-		toIndex := -1
+		var toIndex int
 		destination := strings.ToLower(args[1])
 
 		switch destination {
@@ -358,7 +358,6 @@ Examples:
 			if err != nil {
 				exitWithError("Target track: %v", err)
 			}
-			toIndex = targetIdx
 			// If moving from after target to before, adjust index
 			if fromIndex > targetIdx {
 				toIndex = targetIdx
@@ -431,7 +430,7 @@ func parseQueueTrackArg(arg string, items []kefw2.ContentItem) (int, error) {
 	return index, nil
 }
 
-// queuePlayCmd plays a specific track from the queue
+// queuePlayCmd plays a specific track from the queue.
 var queuePlayCmd = &cobra.Command{
 	Use:   "play <track>",
 	Short: "Play a track from the queue",
@@ -442,7 +441,7 @@ Examples:
   kefw2 queue play "Yesterday"          # Play track by title`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: QueueItemCompletion,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		resp, err := client.GetPlayQueue()
@@ -454,6 +453,7 @@ Examples:
 		}
 
 		arg := args[0]
+
 		var index int
 		var track *kefw2.ContentItem
 

--- a/cmd/kefw2/cmd/queue_playmode.go
+++ b/cmd/kefw2/cmd/queue_playmode.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hilli/go-kef-w2/kefw2"
 )
 
-// queueShuffleCmd controls shuffle mode
+// queueShuffleCmd controls shuffle mode.
 var queueShuffleCmd = &cobra.Command{
 	Use:   "shuffle [on|off]",
 	Short: "Get or set shuffle mode",
@@ -43,7 +43,7 @@ Examples:
   kefw2 queue shuffle off      # Disable shuffle`,
 	Args:      cobra.MaximumNArgs(1),
 	ValidArgs: []string{"on", "off"},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		if len(args) == 0 {
@@ -66,7 +66,7 @@ Examples:
 		switch arg {
 		case "on", "true", "1", "yes":
 			enable = true
-		case "off", "false", "0", "no":
+		case PlayModeOff, "false", "0", "no":
 			enable = false
 		default:
 			exitWithError("Invalid value: %s (use 'on' or 'off')", args[0])
@@ -83,7 +83,7 @@ Examples:
 	},
 }
 
-// queueRepeatCmd controls repeat mode
+// queueRepeatCmd controls repeat mode.
 var queueRepeatCmd = &cobra.Command{
 	Use:   "repeat [off|one|all]",
 	Short: "Get or set repeat mode",
@@ -103,7 +103,7 @@ Examples:
   kefw2 queue repeat all      # Repeat entire queue`,
 	Args:      cobra.MaximumNArgs(1),
 	ValidArgs: []string{"off", "one", "all"},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		if len(args) == 0 {
@@ -138,13 +138,13 @@ Examples:
 	},
 }
 
-// queueModeCmd shows the current play mode
+// queueModeCmd shows the current play mode.
 var queueModeCmd = &cobra.Command{
 	Use:     "mode",
 	Aliases: []string{"status"},
 	Short:   "Show current play mode (shuffle/repeat)",
 	Long:    `Show the current shuffle and repeat settings for queue playback.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 
 		shuffleEnabled, err := client.IsShuffleEnabled()

--- a/cmd/kefw2/cmd/queue_save.go
+++ b/cmd/kefw2/cmd/queue_save.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hilli/go-kef-w2/kefw2"
 )
 
-// SavedQueue represents a saved queue file
+// SavedQueue represents a saved queue file.
 type SavedQueue struct {
 	Name   string       `yaml:"name"`
 	Tracks []SavedTrack `yaml:"tracks"`
@@ -108,7 +108,7 @@ func (t SavedTrack) toContentItem() kefw2.ContentItem {
 	}
 }
 
-// getQueuesDir returns the directory for saved queues
+// getQueuesDir returns the directory for saved queues.
 func getQueuesDir() (string, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
@@ -116,14 +116,14 @@ func getQueuesDir() (string, error) {
 	}
 
 	queuesDir := filepath.Join(configDir, "kefw2", "queues")
-	if err := os.MkdirAll(queuesDir, 0755); err != nil {
+	if err := os.MkdirAll(queuesDir, 0750); err != nil {
 		return "", fmt.Errorf("failed to create queues directory: %w", err)
 	}
 
 	return queuesDir, nil
 }
 
-// getSavedQueuePath returns the path for a saved queue file
+// getSavedQueuePath returns the path for a saved queue file.
 func getSavedQueuePath(name string) (string, error) {
 	queuesDir, err := getQueuesDir()
 	if err != nil {
@@ -138,7 +138,7 @@ func getSavedQueuePath(name string) (string, error) {
 	return filepath.Join(queuesDir, safeName+".yaml"), nil
 }
 
-// listSavedQueues returns a list of saved queue names
+// listSavedQueues returns a list of saved queue names.
 func listSavedQueues() ([]string, error) {
 	queuesDir, err := getQueuesDir()
 	if err != nil {
@@ -168,7 +168,7 @@ func listSavedQueues() ([]string, error) {
 	return names, nil
 }
 
-// queueSaveCmd saves the current queue
+// queueSaveCmd saves the current queue.
 var queueSaveCmd = &cobra.Command{
 	Use:   "save <name>",
 	Short: "Save the current queue to a file",
@@ -183,7 +183,7 @@ Examples:
   kefw2 queue save "workout"
   kefw2 queue save "jazz favorites"`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 		name := args[0]
 
@@ -216,14 +216,14 @@ Examples:
 		exitOnError(err, "Failed to get queue file path")
 
 		// Write to file
-		err = os.WriteFile(filePath, data, 0644)
+		err = os.WriteFile(filePath, data, 0600)
 		exitOnError(err, "Failed to save queue")
 
 		taskConpletedPrinter.Printf("Saved %d tracks to '%s'\n", len(resp.Rows), name)
 	},
 }
 
-// queueLoadCmd loads a saved queue
+// queueLoadCmd loads a saved queue.
 var queueLoadCmd = &cobra.Command{
 	Use:   "load <name>",
 	Short: "Load a saved queue",
@@ -236,7 +236,7 @@ Examples:
   kefw2 queue load "jazz favorites"`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: SavedQueueCompletion,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		client := kefw2.NewAirableClient(currentSpeaker)
 		name := args[0]
 
@@ -245,7 +245,7 @@ Examples:
 		exitOnError(err, "Failed to get queue file path")
 
 		// Read file
-		data, err := os.ReadFile(filePath)
+		data, err := os.ReadFile(filePath) //nolint:gosec // Path is constructed from user's config dir
 		if err != nil {
 			if os.IsNotExist(err) {
 				exitWithError("Saved queue '%s' not found.", name)
@@ -280,13 +280,13 @@ Examples:
 	},
 }
 
-// queueSavedCmd lists saved queues
+// queueSavedCmd lists saved queues.
 var queueSavedCmd = &cobra.Command{
 	Use:     "saved",
 	Aliases: []string{"list-saved"},
 	Short:   "List saved queues",
 	Long:    `List all saved queues stored locally.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		names, err := listSavedQueues()
 		exitOnError(err, "Failed to list saved queues")
 
@@ -302,7 +302,7 @@ var queueSavedCmd = &cobra.Command{
 	},
 }
 
-// queueDeleteSavedCmd deletes a saved queue
+// queueDeleteSavedCmd deletes a saved queue.
 var queueDeleteSavedCmd = &cobra.Command{
 	Use:               "delete-saved <name>",
 	Aliases:           []string{"rm-saved"},
@@ -310,7 +310,7 @@ var queueDeleteSavedCmd = &cobra.Command{
 	Long:              `Delete a previously saved queue file.`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: SavedQueueCompletion,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 
 		filePath, err := getSavedQueuePath(name)
@@ -328,8 +328,8 @@ var queueDeleteSavedCmd = &cobra.Command{
 	},
 }
 
-// SavedQueueCompletion provides tab completion for saved queue names
-func SavedQueueCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// SavedQueueCompletion provides tab completion for saved queue names.
+func SavedQueueCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/kefw2/cmd/root.go
+++ b/cmd/kefw2/cmd/root.go
@@ -56,13 +56,13 @@ var rootCmd = &cobra.Command{
 	Long:  ``,
 }
 
-// noFileCompletion is a ValidArgsFunction that disables file completion
-func noFileCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// noFileCompletion is a ValidArgsFunction that disables file completion.
+func noFileCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 // disableFileCompletionRecursive disables file completion on all commands
-// that don't have a custom ValidArgsFunction set
+// that don't have a custom ValidArgsFunction set.
 func disableFileCompletionRecursive(cmd *cobra.Command) {
 	if cmd.ValidArgsFunction == nil {
 		cmd.ValidArgsFunction = noFileCompletion

--- a/cmd/kefw2/cmd/upnp_index.go
+++ b/cmd/kefw2/cmd/upnp_index.go
@@ -83,7 +83,7 @@ func LoadTrackIndex() (*TrackIndex, error) {
 	defer trackIndexMu.RUnlock()
 
 	indexPath := getTrackIndexPath()
-	data, err := os.ReadFile(indexPath)
+	data, err := os.ReadFile(indexPath) //nolint:gosec // Path is constructed from user's cache dir
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil // No index yet
@@ -112,7 +112,7 @@ func SaveTrackIndex(index *TrackIndex) error {
 	indexPath := getTrackIndexPath()
 
 	// Ensure directory exists
-	if err := os.MkdirAll(filepath.Dir(indexPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0750); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func SaveTrackIndex(index *TrackIndex) error {
 		return err
 	}
 
-	return os.WriteFile(indexPath, data, 0644)
+	return os.WriteFile(indexPath, data, 0600)
 }
 
 // IsTrackIndexFresh checks if the track index is fresh enough to use.
@@ -233,7 +233,7 @@ func findContainerByPath(client *kefw2.AirableClient, serverPath, containerPath 
 		var availableContainers []string
 
 		for _, item := range resp.Rows {
-			if item.Type == "container" {
+			if item.Type == TypeContainer {
 				availableContainers = append(availableContainers, item.Title)
 				if strings.ToLower(item.Title) == partLower {
 					currentPath = item.Path
@@ -353,7 +353,7 @@ func scoreTrack(track *IndexedTrack, queryParts []string) int {
 	return totalScore
 }
 
-// Score constants for ranking
+// Score constants for ranking.
 const (
 	scoreExactField   = 100 // Exact match on entire field (artist="earth")
 	scoreExactWord    = 50  // Exact word match (title="Down to Earth")

--- a/kefw2/airable.go
+++ b/kefw2/airable.go
@@ -2,6 +2,7 @@ package kefw2
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -175,7 +176,7 @@ func (a *AirableClient) GetRows(path string, from, to int) (*RowsResponse, error
 	requestURL := fmt.Sprintf("http://%s/api/getRows?path=%s&roles=@all&from=%d&to=%d",
 		a.Speaker.IPAddress, url.QueryEscape(path), from, to)
 
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -265,7 +266,7 @@ func (a *AirableClient) SetData(payload interface{}) (*SetDataResponse, error) {
 	}
 
 	requestURL := fmt.Sprintf("http://%s/api/setData", a.Speaker.IPAddress)
-	req, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewBuffer(payloadJSON))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, requestURL, bytes.NewBuffer(payloadJSON))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -297,7 +298,7 @@ func (a *AirableClient) GetData(path string) ([]byte, error) {
 	requestURL := fmt.Sprintf("http://%s/api/getData?path=%s&roles=value",
 		a.Speaker.IPAddress, url.QueryEscape(path))
 
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -334,7 +335,7 @@ func (a *AirableClient) PollEvents(timeout int) ([]interface{}, error) {
 	requestURL := fmt.Sprintf("http://%s/api/event/pollQueue?queueId=%s&timeout=%d",
 		a.Speaker.IPAddress, url.QueryEscape(a.QueueID), timeout)
 
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/kefw2/airable_podcast.go
+++ b/kefw2/airable_podcast.go
@@ -10,7 +10,7 @@ import (
 // Podcasts are accessed via the Airable feeds service.
 
 // GetPodcastMenu returns the top-level podcast menu.
-// Entry point: ui:/airablefeeds
+// Entry point: ui:/airablefeeds.
 func (a *AirableClient) GetPodcastMenu() (*RowsResponse, error) {
 	resp, err := a.GetRows("ui:/airablefeeds", 0, 19)
 	if err != nil {
@@ -99,7 +99,7 @@ func (a *AirableClient) GetPodcastEpisodesAll(podcastPath string) (*RowsResponse
 
 	// Find the Episodes container
 	for _, item := range resp.Rows {
-		if item.Title == "Episodes" && item.Type == "container" {
+		if item.Title == "Episodes" && item.Type == ContentTypeContainer {
 			return a.GetAllRows(item.Path)
 		}
 	}
@@ -117,7 +117,7 @@ func (a *AirableClient) GetLatestEpisode(podcast *ContentItem) (*ContentItem, er
 	// Find the Episodes container in the response
 	var episodesPath string
 	for _, item := range resp.Rows {
-		if item.Title == "Episodes" && item.Type == "container" {
+		if item.Title == "Episodes" && item.Type == ContentTypeContainer {
 			episodesPath = item.Path
 			break
 		}
@@ -179,7 +179,7 @@ func (a *AirableClient) RemovePodcastFavorite(podcast *ContentItem) error {
 }
 
 // BrowsePodcastByDisplayPath browses using a display path (title-based).
-// Example: "Favorites" or "Popular/Tech"
+// Example: "Favorites" or "Popular/Tech".
 func (a *AirableClient) BrowsePodcastByDisplayPath(displayPath string) (*RowsResponse, error) {
 	return a.browseByDisplayPath(ServicePodcast, displayPath)
 }

--- a/kefw2/airable_radio.go
+++ b/kefw2/airable_radio.go
@@ -9,7 +9,7 @@ import (
 // Internet radio stations are accessed via the Airable service.
 
 // GetRadioMenu returns the top-level radio menu.
-// Entry point: ui:/airableradios
+// Entry point: ui:/airableradios.
 func (a *AirableClient) GetRadioMenu() (*RowsResponse, error) {
 	resp, err := a.GetRows("ui:/airableradios", 0, 19)
 	if err != nil {
@@ -204,7 +204,7 @@ func (a *AirableClient) ResolveAndPlayRadioStation(station *ContentItem) error {
 }
 
 // BrowseRadioByDisplayPath browses using a display path (title-based).
-// Example: "Favorites" or "by Genre/Jazz"
+// Example: "Favorites" or "by Genre/Jazz".
 func (a *AirableClient) BrowseRadioByDisplayPath(displayPath string) (*RowsResponse, error) {
 	return a.browseByDisplayPath(ServiceRadio, displayPath)
 }
@@ -215,6 +215,7 @@ func (a *AirableClient) BrowseRadioByItemPath(itemPath string) (*RowsResponse, e
 }
 
 // BrowseRadioPath browses the radio hierarchy at the given path.
+//
 // Deprecated: Use BrowseRadioByDisplayPath instead.
 func (a *AirableClient) BrowseRadioPath(browsePath string) (*RowsResponse, error) {
 	return a.BrowseRadioByDisplayPath(browsePath)

--- a/kefw2/airable_service.go
+++ b/kefw2/airable_service.go
@@ -9,13 +9,13 @@ import (
 type AirableServiceType string
 
 const (
-	// ServiceRadio represents the internet radio service
+	// ServiceRadio represents the internet radio service.
 	ServiceRadio AirableServiceType = "radios"
-	// ServicePodcast represents the podcast/feeds service
+	// ServicePodcast represents the podcast/feeds service.
 	ServicePodcast AirableServiceType = "feeds"
 )
 
-// serviceConfig holds configuration for each service type
+// serviceConfig holds configuration for each service type.
 type serviceConfig struct {
 	entryPoint  string // Initial path to discover the service
 	urlPath     string // Path segment in the base URL (e.g., "/airable/radios")
@@ -23,7 +23,7 @@ type serviceConfig struct {
 	serviceName string // Human-readable name for error messages
 }
 
-// serviceConfigs maps service types to their configurations
+// serviceConfigs maps service types to their configurations.
 var serviceConfigs = map[AirableServiceType]serviceConfig{
 	ServiceRadio: {
 		entryPoint:  "ui:/airableradios",
@@ -200,7 +200,7 @@ func (a *AirableClient) modifyFavorite(service AirableServiceType, item *Content
 //   - "airable://airable.feeds/podcast/12345"
 //   - "airable://airable/feeds/12345"
 //
-// Output: the last non-keyword segment (e.g., "1022963300812989" or "12345")
+// Output: the last non-keyword segment (e.g., "1022963300812989" or "12345").
 func extractItemID(id string) string {
 	// Split by "/" and find the last meaningful segment
 	parts := strings.Split(id, "/")

--- a/kefw2/airable_upnp.go
+++ b/kefw2/airable_upnp.go
@@ -10,19 +10,19 @@ import (
 // Access local media servers like Plex, Sonos, etc.
 
 // GetMediaServers returns the list of available UPnP/DLNA media servers.
-// Entry point: ui:/upnp
+// Entry point: ui:/upnp.
 func (a *AirableClient) GetMediaServers() (*RowsResponse, error) {
 	return a.GetRows("ui:/upnp", 0, 19)
 }
 
 // BrowseMediaServer browses the root of a media server.
-// serverPath should be in format: upnp:/uuid:{uuid}?itemType=server
+// serverPath should be in format: upnp:/uuid:{uuid}?itemType=server.
 func (a *AirableClient) BrowseMediaServer(serverPath string) (*RowsResponse, error) {
 	return a.GetRows(serverPath, 0, 50)
 }
 
 // BrowseContainer browses a container (folder/album) on a media server.
-// containerPath should be in format: upnp:/uuid:{uuid}/{containerID}?itemType=container
+// containerPath should be in format: upnp:/uuid:{uuid}/{containerID}?itemType=container.
 func (a *AirableClient) BrowseContainer(containerPath string) (*RowsResponse, error) {
 	return a.GetRows(containerPath, 0, 100)
 }
@@ -76,7 +76,7 @@ func (a *AirableClient) GetPlayQueue() (*RowsResponse, error) {
 }
 
 // PlayUPnPContainer plays all tracks from a container (album/folder).
-// This follows the pattern: clear playlist → add all items → play from index 0
+// This follows the pattern: clear playlist → add all items → play from index 0.
 func (a *AirableClient) PlayUPnPContainer(containerPath string) error {
 	// Get the container contents
 	resp, err := a.BrowseContainer(containerPath)
@@ -87,7 +87,7 @@ func (a *AirableClient) PlayUPnPContainer(containerPath string) error {
 	// Filter to only audio tracks
 	var tracks []ContentItem
 	for _, item := range resp.Rows {
-		if item.Type == "audio" {
+		if item.Type == ContentTypeAudio {
 			tracks = append(tracks, item)
 		}
 	}
@@ -100,7 +100,7 @@ func (a *AirableClient) PlayUPnPContainer(containerPath string) error {
 }
 
 // PlayUPnPTracks plays a list of UPnP tracks using playlist-based playback.
-// Pattern: clear playlist → add items via pl/addexternalitems → play from player:player/control
+// Pattern: clear playlist → add items via pl/addexternalitems → play from player:player/control.
 func (a *AirableClient) PlayUPnPTracks(tracks []ContentItem) error {
 	if len(tracks) == 0 {
 		return fmt.Errorf("no tracks provided")
@@ -477,9 +477,10 @@ func (a *AirableClient) getAllTracksRecursive(containerPath string, progress Ind
 	}
 
 	for _, item := range resp.Rows {
-		if item.Type == "audio" {
+		switch item.Type {
+		case "audio":
 			tracks = append(tracks, item)
-		} else if item.Type == "container" {
+		case "container":
 			subContainers = append(subContainers, item)
 		}
 	}

--- a/kefw2/cache.go
+++ b/kefw2/cache.go
@@ -98,7 +98,7 @@ func NewRowsCache(config CacheConfig) *RowsCache {
 
 	// Create cache directory if needed
 	if cache.persistDir != "" {
-		_ = os.MkdirAll(cache.persistDir, 0755)
+		_ = os.MkdirAll(cache.persistDir, 0750)
 	}
 
 	// Load existing cache from disk
@@ -239,7 +239,7 @@ func (c *RowsCache) saveLocked() error {
 		return err
 	}
 
-	if err := os.WriteFile(c.cacheFilePath(), data, 0644); err != nil {
+	if err := os.WriteFile(c.cacheFilePath(), data, 0600); err != nil {
 		return err
 	}
 

--- a/kefw2/constants.go
+++ b/kefw2/constants.go
@@ -1,0 +1,7 @@
+package kefw2
+
+// Content type constants used across the codebase.
+const (
+	ContentTypeAudio     = "audio"
+	ContentTypeContainer = "container"
+)

--- a/kefw2/queue.go
+++ b/kefw2/queue.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Play mode constants for queue playback
+// Play mode constants for queue playback.
 const (
 	PlayModeNormal           = "normal"
 	PlayModeRepeatOne        = "repeatOne"
@@ -223,11 +223,12 @@ func (a *AirableClient) SetShuffle(enabled bool) error {
 			newMode = PlayModeShuffle
 		}
 	} else {
-		if hasRepeatAll {
+		switch {
+		case hasRepeatAll:
 			newMode = PlayModeRepeatAll
-		} else if hasRepeatOne {
+		case hasRepeatOne:
 			newMode = PlayModeRepeatOne
-		} else {
+		default:
 			newMode = PlayModeNormal
 		}
 	}


### PR DESCRIPTION
The track index was missing the audio file URI and MIME type, which are required by the KEF speaker to play tracks. This caused 'upnp search' results to fail when playing or adding to queue, while 'upnp browse' worked correctly (as it fetched full track data).

Changes:
- Add URI and MimeType fields to IndexedTrack struct
- Store these fields when building the index
- Include them when converting IndexedTrack back to ContentItem
- Bump index version to 2 (old indexes are auto-invalidated)
- Update CHANGELOG.md for v0.2.3

Users need to run 'kefw2 upnp index --rebuild' once after this update.