### PR TITLE
Improve station selection logic for radio playback

### DIFF
--- a/cmd/kefw2/cmd/radio.go
+++ b/cmd/kefw2/cmd/radio.go
@@ -564,11 +564,23 @@ var radioPlayCmd = &cobra.Command{
 			exitWithError("No playable stations found.")
 		}
 
-		// If only one result, play it directly
+		var station *kefw2.ContentItem
+
 		if len(stations) == 1 {
-			station := stations[0]
+			station = &stations[0]
+		} else {
+			for _, s := range stations {
+				if strings.EqualFold(s.Title, query) {
+					station = &s
+					break
+				}
+			}
+		}
+
+		// Single result or exact match - play directly
+		if station != nil {
 			headerPrinter.Printf("Playing: %s\n", station.Title)
-			err := client.PlayRadioStation(&station)
+			err := client.PlayRadioStation(station)
 			exitOnError(err, "Failed to play")
 			taskConpletedPrinter.Printf("Now playing: %s\n", station.Title)
 			return


### PR DESCRIPTION
Instantly play the provided radio station if the provided station name matches one of the results exactly. See my comment https://github.com/hilli/go-kef-w2/issues/9#issuecomment-3847755197 for more context.