### PR TITLE
Fix radio browse with no args to show interactive picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `radio browse` with no arguments now shows the interactive picker instead of attempting to auto-play
+- Improve station selection logic for radio playback
+- `radio browse` with no arguments now shows the interactive picker instead of attempting to auto
 
 ## [0.2.3] - 2025-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-02-04
+
+### Fixed
+
+- `radio browse` with no arguments now shows the interactive picker instead of attempting to auto-play
+
 ## [0.2.3] - 2025-02-04
 
 ### Fixed
@@ -366,7 +372,8 @@ Implemented by: `Source`, `SpeakerStatus`, `CableMode`
 
 7. **Update player ID field access**: If you access `playId.SystemMemberId`, change it to `playId.SystemMemberID`.
 
-[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/hilli/go-kef-w2/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/hilli/go-kef-w2/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/hilli/go-kef-w2/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/hilli/go-kef-w2/compare/v0.2.0...v0.2.1

--- a/cmd/kefw2/cmd/radio.go
+++ b/cmd/kefw2/cmd/radio.go
@@ -731,8 +731,9 @@ an interactive fuzzy-filter picker.`,
 			}
 		}
 
-		// If there's exactly 1 playable item, play/save it directly (no picker)
-		if len(playableItems) == 1 && !saveFavoriteFlag {
+		// If there's exactly 1 playable item AND a path was specified, play/save it directly (no picker)
+		// When browsePath is empty (no args), always show the interactive picker
+		if len(playableItems) == 1 && !saveFavoriteFlag && browsePath != "" {
 			station := &playableItems[0]
 			headerPrinter.Printf("Playing: %s\n", station.Title)
 			err := client.ResolveAndPlayRadioStation(station)
@@ -741,7 +742,7 @@ an interactive fuzzy-filter picker.`,
 			return
 		}
 
-		if len(playableItems) == 1 && saveFavoriteFlag {
+		if len(playableItems) == 1 && saveFavoriteFlag && browsePath != "" {
 			station := &playableItems[0]
 			headerPrinter.Printf("Saving: %s\n", station.Title)
 			err := client.AddRadioFavorite(station)


### PR DESCRIPTION
## Summary

- `radio browse` with no arguments now shows the interactive picker instead of attempting to auto-play
- Auto-play behavior preserved when a specific path is provided

Fixes the issue where running `kefw2 radio browse` with no arguments would attempt to play a filter/pseudo-item and fail with a timeout error.