### PR TITLE
feat: add seek command for jumping to position in tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-02-05
+
+### Added
+
+- **Seek Command**: New `kefw2 seek <position>` command for jumping to a specific position in the current track
+  - Supports multiple time formats: `hh:mm:ss`, `mm:ss`, or seconds
+  - Examples: `seek 1:30` (1 min 30 sec), `seek 1:23:45` (1 hr 23 min 45 sec), `seek 90` (90 seconds)
+- **Library: SeekTo method**: New `SeekTo(ctx, positionMS)` method for programmatic seeking within tracks
+
 ## [0.2.4] - 2026-02-04
 
 ### Fixed
@@ -373,7 +382,8 @@ Implemented by: `Source`, `SpeakerStatus`, `CableMode`
 
 7. **Update player ID field access**: If you access `playId.SystemMemberId`, change it to `playId.SystemMemberID`.
 
-[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/hilli/go-kef-w2/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/hilli/go-kef-w2/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/hilli/go-kef-w2/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/hilli/go-kef-w2/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/hilli/go-kef-w2/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ kefw2 play
 kefw2 pause
 ```
 
+Seek to a specific position in the current track or podcast
+
+```shell
+# Seek to 5 minutes and 30 seconds
+kefw2 seek 5:30
+
+# Seek to 1 hour, 23 minutes, 45 seconds
+kefw2 seek 1:23:45
+
+# Seek to 90 seconds
+kefw2 seek 90
+```
+
 Turn the speakers off
 
 ```shell
@@ -333,6 +346,7 @@ kefw2 events --json
 - [x] Get status
 - [x] Turn on/off
 - [x] Track next/previous
+- [x] Seek within tracks
 - [x] Discover speakers automatically
 - [x] Display cover art in ASCII (wifi media)
 - [x] Backup speaker settings/eq profiles to file

--- a/cmd/kefw2/cmd/seek.go
+++ b/cmd/kefw2/cmd/seek.go
@@ -1,0 +1,174 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// seekCmd allows seeking to a specific position in the current track.
+var seekCmd = &cobra.Command{
+	Use:   "seek <position>",
+	Short: "Seek to a position in the current track or podcast",
+	Long: `Seek to a specific position in the currently playing track or podcast.
+
+Position can be specified in the following formats:
+  hh:mm:ss  - Hours, minutes, and seconds (e.g., 1:23:45)
+  mm:ss     - Minutes and seconds (e.g., 5:30)
+  seconds   - Just seconds (e.g., 90)
+
+Examples:
+  kefw2 seek 1:23:45   # Seek to 1 hour, 23 minutes, 45 seconds
+  kefw2 seek 5:30      # Seek to 5 minutes, 30 seconds
+  kefw2 seek 90        # Seek to 90 seconds (1:30)`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		// Check if we can control playback
+		canControlPlayback, err := currentSpeaker.CanControlPlayback(ctx)
+		exitOnError(err, "Can't query source")
+		if !canControlPlayback {
+			exitWithError("Can only seek on WiFi/Bluetooth source.")
+		}
+
+		// Check if something is playing
+		isPlaying, err := currentSpeaker.IsPlaying(ctx)
+		exitOnError(err, "Can't check playback state")
+		if !isPlaying {
+			exitWithError("Nothing is currently playing.")
+		}
+
+		// Parse the position argument
+		positionMS, err := parseTimePosition(args[0])
+		exitOnError(err, "Invalid time format")
+
+		// Get track duration for validation
+		pd, err := currentSpeaker.PlayerData(ctx)
+		exitOnError(err, "Can't get player data")
+
+		// Validate position against duration (skip for live streams where duration is 0)
+		if pd.Status.Duration > 0 && int(positionMS) > pd.Status.Duration {
+			exitWithError("Cannot seek to %s - track is only %s long.",
+				formatDuration(int(positionMS)),
+				formatDuration(pd.Status.Duration))
+		}
+
+		// Perform the seek
+		err = currentSpeaker.SeekTo(ctx, positionMS)
+		exitOnError(err, "Failed to seek")
+
+		taskConpletedPrinter.Printf("Seeked to %s\n", formatDuration(int(positionMS)))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(seekCmd)
+}
+
+// parseTimePosition parses a time string in formats hh:mm:ss, mm:ss, or seconds
+// and returns the position in milliseconds.
+func parseTimePosition(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty time value")
+	}
+
+	parts := strings.Split(s, ":")
+
+	switch len(parts) {
+	case 1:
+		// Just seconds
+		sec, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid time: %s", s)
+		}
+		if sec < 0 {
+			return 0, fmt.Errorf("time cannot be negative")
+		}
+		return sec * 1000, nil
+
+	case 2:
+		// mm:ss
+		min, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid minutes: %s", parts[0])
+		}
+		sec, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid seconds: %s", parts[1])
+		}
+		if min < 0 {
+			return 0, fmt.Errorf("minutes cannot be negative")
+		}
+		if sec < 0 || sec >= 60 {
+			return 0, fmt.Errorf("seconds must be 0-59")
+		}
+		return (min*60 + sec) * 1000, nil
+
+	case 3:
+		// hh:mm:ss
+		hours, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid hours: %s", parts[0])
+		}
+		min, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid minutes: %s", parts[1])
+		}
+		sec, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid seconds: %s", parts[2])
+		}
+		if hours < 0 {
+			return 0, fmt.Errorf("hours cannot be negative")
+		}
+		if min < 0 || min >= 60 {
+			return 0, fmt.Errorf("minutes must be 0-59")
+		}
+		if sec < 0 || sec >= 60 {
+			return 0, fmt.Errorf("seconds must be 0-59")
+		}
+		return (hours*3600 + min*60 + sec) * 1000, nil
+
+	default:
+		return 0, fmt.Errorf("invalid time format: %s (use hh:mm:ss, mm:ss, or seconds)", s)
+	}
+}
+
+// formatDuration formats milliseconds to a human-readable time string.
+// Returns h:mm:ss for durations >= 1 hour, otherwise mm:ss.
+func formatDuration(ms int) string {
+	totalSeconds := ms / 1000
+	hours := totalSeconds / 3600
+	minutes := (totalSeconds % 3600) / 60
+	seconds := totalSeconds % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, seconds)
+	}
+	return fmt.Sprintf("%d:%02d", minutes, seconds)
+}

--- a/cmd/kefw2/cmd/seek_test.go
+++ b/cmd/kefw2/cmd/seek_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParseTimePosition(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		// Valid seconds only
+		{"zero seconds", "0", 0, false},
+		{"90 seconds", "90", 90000, false},
+		{"large seconds", "3600", 3600000, false},
+
+		// Valid mm:ss
+		{"5:30", "5:30", 330000, false},
+		{"0:45", "0:45", 45000, false},
+		{"10:00", "10:00", 600000, false},
+		{"99:59", "99:59", 5999000, false},
+
+		// Valid hh:mm:ss
+		{"1:00:00", "1:00:00", 3600000, false},
+		{"1:23:45", "1:23:45", 5025000, false},
+		{"0:05:30", "0:05:30", 330000, false},
+		{"10:30:15", "10:30:15", 37815000, false},
+
+		// Invalid formats
+		{"empty", "", 0, true},
+		{"negative seconds", "-5", 0, true},
+		{"seconds out of range mm:ss", "5:60", 0, true},
+		{"seconds out of range hh:mm:ss", "1:30:60", 0, true},
+		{"minutes out of range hh:mm:ss", "1:60:30", 0, true},
+		{"too many colons", "1:2:3:4", 0, true},
+		{"non-numeric", "abc", 0, true},
+		{"mixed non-numeric", "5:abc", 0, true},
+
+		// Edge cases
+		{"whitespace", "  90  ", 90000, false},
+		{"negative in mm:ss", "-5:30", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimePosition(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseTimePosition(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseTimePosition(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   int
+		want string
+	}{
+		{"zero", 0, "0:00"},
+		{"45 seconds", 45000, "0:45"},
+		{"5 minutes 30 seconds", 330000, "5:30"},
+		{"1 hour", 3600000, "1:00:00"},
+		{"1:23:45", 5025000, "1:23:45"},
+		{"10:30:15", 37815000, "10:30:15"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDuration(tt.ms); got != tt.want {
+				t.Errorf("formatDuration(%v) = %v, want %v", tt.ms, got, tt.want)
+			}
+		})
+	}
+}

--- a/kefw2/kefw2.go
+++ b/kefw2/kefw2.go
@@ -358,3 +358,14 @@ func (s *KEFSpeaker) SongProgress(ctx context.Context) (string, error) {
 func (s *KEFSpeaker) SongProgressMS(ctx context.Context) (int, error) {
 	return parseTypedInt(s.getData(ctx, "player:player/data/playTime"))
 }
+
+// SeekTo seeks to a specific position in the current track.
+// positionMS is the position in milliseconds.
+func (s *KEFSpeaker) SeekTo(ctx context.Context, positionMS int64) error {
+	// Use the player control path with seekTime control
+	// Format: {"control": "seekTime", "time": <milliseconds>}
+	return s.setActivateMap(ctx, "player:player/control", map[string]any{
+		"control": "seekTime",
+		"time":    positionMS,
+	})
+}


### PR DESCRIPTION
Add new 'kefw2 seek <position>' command that allows jumping to a specific position in the current track. Supports flexible time input formats:
- hh:mm:ss (e.g., 1:23:45)
- mm:ss (e.g., 5:30)
- seconds (e.g., 90)

Library changes:
- Add SeekTo(ctx, positionMS) method for programmatic seeking
- Add setActivateMap helper for player control commands with mixed types
- Add int64 type support to setTypedValue for i64_ values

The seek uses the player:player/control endpoint with the seekTime control, matching the KEF Connect app's behavior.