### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/hilli/go-kef-w2/security/code-scanning/1](https://github.com/hilli/go-kef-w2/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes. For a GoReleaser-based release workflow that creates GitHub releases and uploads assets, the job typically needs `contents: write` (to create releases and attach assets) and possibly `packages: write` if it publishes to GitHub Packages. It does not need broader permissions like `actions`, `checks`, or `pull-requests`. The safest approach here, without changing existing behavior, is to add a job-level `permissions` block under `jobs.release` that explicitly allows `contents: write` and `packages: write`. This will limit the default `GITHUB_TOKEN` while still allowing any operations GoReleaser performs via that token, should it ever be used, and will clearly document required scopes.

Concretely, in `.github/workflows/release.yaml`, under `jobs:`, inside the `release:` job (around line 11), insert a `permissions:` section aligned with other job keys. For example:

```yaml
  release:
    name: Release
    permissions:
      contents: write
      packages: write
    runs-on: ubuntu-24.04
    steps:
      ...
```

No additional imports or external dependencies are needed; this is purely a YAML configuration change to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
