### PR TITLE
Add reboot and scheduled-reboot support

### DIFF
--- a/cmd/kefw2/cmd/reboot.go
+++ b/cmd/kefw2/cmd/reboot.go
@@ -1,0 +1,129 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var dayNames = []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
+
+func dayName(d int) string {
+	if d < 0 || d >= len(dayNames) {
+		return "Unknown"
+	}
+	return dayNames[d]
+}
+
+// rebootCmd triggers an immediate reboot of the speaker.
+var rebootCmd = &cobra.Command{
+	Use:   "reboot",
+	Short: "Reboot the speaker now",
+	Long:  `Reboot the speaker immediately. Use 'reboot schedule' to manage automatic scheduled reboots.`,
+	Args:  cobra.MaximumNArgs(0),
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx := cmd.Context()
+		err := currentSpeaker.Reboot(ctx)
+		exitOnError(err, "Failed to reboot speaker")
+		taskConpletedPrinter.Println("Reboot command sent")
+	},
+}
+
+var (
+	rebootScheduleEnable  bool
+	rebootScheduleDisable bool
+	rebootScheduleDay     int
+	rebootScheduleTime    string
+)
+
+// rebootScheduleCmd manages the automatic scheduled reboot.
+var rebootScheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "Get or set the scheduled automatic reboot",
+	Long: `Display or update the speaker's scheduled automatic reboot.
+
+With no flags, prints the current schedule. Use --enable/--disable to toggle
+the schedule, and --day/--time to change when it runs. Day uses 0=Sunday
+through 6=Saturday (encoding not yet confirmed against the KEF Connect app).`,
+	Args: cobra.MaximumNArgs(0),
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx := cmd.Context()
+
+		dayChanged := cmd.Flags().Changed("day")
+		timeChanged := cmd.Flags().Changed("time")
+		enableChanged := cmd.Flags().Changed("enable")
+		disableChanged := cmd.Flags().Changed("disable")
+
+		if rebootScheduleEnable && rebootScheduleDisable {
+			exitOnError(fmt.Errorf("--enable and --disable are mutually exclusive"), "Invalid flags")
+		}
+
+		anyChange := dayChanged || timeChanged || enableChanged || disableChanged
+
+		if anyChange {
+			sr, err := currentSpeaker.GetScheduledReboot(ctx)
+			exitOnError(err, "Failed to read current scheduled reboot")
+
+			if dayChanged {
+				sr.DayOfWeek = rebootScheduleDay
+			}
+			if timeChanged {
+				sr.Time = rebootScheduleTime
+			}
+			if enableChanged {
+				sr.Enabled = rebootScheduleEnable
+			}
+			if disableChanged && rebootScheduleDisable {
+				sr.Enabled = false
+			}
+
+			err = currentSpeaker.SetScheduledReboot(ctx, sr)
+			exitOnError(err, "Failed to set scheduled reboot")
+		}
+
+		sr, err := currentSpeaker.GetScheduledReboot(ctx)
+		exitOnError(err, "Failed to read scheduled reboot")
+
+		state := "disabled"
+		if sr.Enabled {
+			state = "enabled"
+		}
+		headerPrinter.Print("Scheduled reboot: ")
+		contentPrinter.Println(state)
+		headerPrinter.Print("Day: ")
+		contentPrinter.Printf("%s (%d)\n", dayName(sr.DayOfWeek), sr.DayOfWeek)
+		headerPrinter.Print("Time: ")
+		contentPrinter.Println(sr.Time)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rebootCmd)
+	rebootCmd.AddCommand(rebootScheduleCmd)
+
+	rebootScheduleCmd.Flags().BoolVar(&rebootScheduleEnable, "enable", false, "Enable the scheduled reboot")
+	rebootScheduleCmd.Flags().BoolVar(&rebootScheduleDisable, "disable", false, "Disable the scheduled reboot")
+	rebootScheduleCmd.Flags().IntVar(&rebootScheduleDay, "day", 0, "Day of week (0=Sunday..6=Saturday)")
+	rebootScheduleCmd.Flags().StringVar(&rebootScheduleTime, "time", "", "Time in HH:MM (24-hour) format")
+}

--- a/kefw2/airable_upnp.go
+++ b/kefw2/airable_upnp.go
@@ -3,6 +3,7 @@ package kefw2
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -512,7 +513,7 @@ func (a *AirableClient) getAllTracksRecursive(containerPath string, progress Ind
 	for _, container := range subContainers {
 		subTracks, err := a.getAllTracksRecursive(container.Path, progress, state)
 		if err != nil {
-			// Log but continue with other containers
+			log.Printf("Warning: failed to scan container %q: %v", container.Path, err)
 			continue
 		}
 		tracks = append(tracks, subTracks...)

--- a/kefw2/auth.go
+++ b/kefw2/auth.go
@@ -1,0 +1,248 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package kefw2
+
+// This file implements the HMAC_SHA256 authenticated channel exposed by the
+// KEF W2 firmware on TLS port 4430. The protocol details were recovered by
+// decompiling the official KEF Connect Android app (jadx):
+//
+//   - Credential derivation: k5/b.java:1103-1118
+//   - HMAC signer:           C9/c.java
+//   - User provisioning:     C9/s.java
+//
+// Username defaults to a hardcoded fallback UUID used by the app when no
+// device id is available; the password is hex(MD5("yek_" + username + "_user")).
+// Provisioning the user is idempotent ("already exists" is treated as success).
+//
+// TLS pinning against the embedded KEF-CA root is not implemented yet; we use
+// InsecureSkipVerify on the 4430 endpoint until the cert is embedded.
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+func init() {
+	if v := os.Getenv("KEFW2_AUTH_DEBUG"); v == "1" || v == "true" {
+		authDebug = true
+	}
+}
+
+const (
+	// authPort is the TLS port serving the authenticated control API.
+	authPort = 4430
+
+	// authFallbackUsername mirrors the hardcoded fallback in
+	// k5/b.java:1103-1118 used when the app has no device id.
+	authFallbackUsername = "7f3c2a91-4d0b-4f65-9b3a-8e2f1c6d4a13"
+
+	// authPathSetData is the endpoint used for both provisioning and
+	// authenticated mutations.
+	authPathSetData = "/api/setData"
+)
+
+var (
+	authClientOnce sync.Once
+	authClient     *http.Client
+
+	// authDebug enables verbose stderr logging of the auth/provisioning flow.
+	// Toggle via env KEFW2_AUTH_DEBUG=1 — see init() below.
+	authDebug bool
+)
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// authHTTPClient returns a TLS client suitable for the 4430 endpoint.
+//
+// TODO: embed the KEF-CA root from the Android app (p.java) and pin against
+// it instead of skipping verification.
+func authHTTPClient() *http.Client {
+	authClientOnce.Do(func() {
+		authClient = &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
+	})
+	return authClient
+}
+
+// authCredentials returns the username/password pair used to talk to the
+// authenticated API. Matches k5/b.java:1103-1118.
+func authCredentials() (username, password string) {
+	username = authFallbackUsername
+	sum := md5.Sum([]byte("yek_" + username + "_user"))
+	password = hex.EncodeToString(sum[:])
+	return username, password
+}
+
+// provisionAuthUser performs an idempotent webserver:addUser POST so that
+// subsequent signed requests are accepted. Mirrors C9/s.java.
+func (s *KEFSpeaker) provisionAuthUser(ctx context.Context) error {
+	username, password := authCredentials()
+	body := map[string]any{
+		"path": "webserver:addUser",
+		"role": "activate",
+		"value": map[string]string{
+			"name":     username,
+			"password": password,
+			"title":    "",
+		},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal addUser body: %w", err)
+	}
+
+	url := fmt.Sprintf("https://%s:%d%s", s.IPAddress, authPort, authPathSetData)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("build addUser request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := authHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("addUser: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if authDebug {
+		fmt.Printf("[auth] provision addUser status=%d resp=%s\n",
+			resp.StatusCode, truncate(respBody, 300))
+	}
+	// 2xx → success. The firmware returns 500 with an "already exists" style
+	// message when the user is present; treat that as success too.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	if bytes.Contains(bytes.ToLower(respBody), []byte("exist")) {
+		return nil
+	}
+	return fmt.Errorf("addUser: HTTP %d: %s", resp.StatusCode, string(respBody))
+}
+
+// signAuthHeader builds the HMAC_SHA256 Authorization header value.
+// Mirrors C9/c.java. The canonical string uses the FULL request URL
+// (scheme://host:port/path), not just the path — see Jd/s.java:36,208-210
+// where field `i` is the full URL and `toString()` returns it verbatim,
+// and C9/c.java:144 appends `sVar.i` directly. For POST the raw request
+// body is appended (NOT a hash of it).
+func signAuthHeader(username, password, fullURL string, body []byte, isPOST bool) (string, error) {
+	nonceRaw := make([]byte, 6)
+	if _, err := rand.Read(nonceRaw); err != nil {
+		return "", fmt.Errorf("nonce: %w", err)
+	}
+	nonce := base64.StdEncoding.EncodeToString(nonceRaw)
+	// Double base64-encode: encode the UTF-8 bytes of the first encoding.
+	nonceB64 := base64.StdEncoding.EncodeToString([]byte(nonce))
+	usernameB64 := base64.StdEncoding.EncodeToString([]byte(username))
+	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	// derivedKey = SHA-256(nonce_utf8 + password_utf8), raw 32 bytes.
+	h := sha256.New()
+	h.Write([]byte(nonce))
+	h.Write([]byte(password))
+	derivedKey := h.Sum(nil)
+
+	// NOTE: canonical uses the DOUBLE-base64 nonce (nonceB64), not the raw
+	// single-encoded nonce. See C9/c.java:140 (strEncodeToString2).
+	canonical := username + "." + nonceB64 + "." + timestamp + "." + fullURL
+	if isPOST {
+		canonical += "." + string(body)
+	}
+
+	mac := hmac.New(sha256.New, derivedKey)
+	mac.Write([]byte(canonical))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	return "HMAC_SHA256 " + usernameB64 + "." + nonceB64 + "." + timestamp + "." + signature, nil
+}
+
+// doAuthenticatedPOST issues a signed POST to the 4430 endpoint, provisioning
+// the auth user on first 401.
+func (s *KEFSpeaker) doAuthenticatedPOST(ctx context.Context, path string, body []byte) (*http.Response, []byte, error) {
+	username, password := authCredentials()
+
+	url := fmt.Sprintf("https://%s:%d%s", s.IPAddress, authPort, path)
+
+	send := func() (*http.Response, []byte, error) {
+		auth, err := signAuthHeader(username, password, url, body, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", auth)
+
+		resp, err := authHTTPClient().Do(req)
+		if err != nil {
+			return nil, nil, err
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if authDebug {
+			fmt.Printf("[auth] POST %s status=%d canonical-len=%d body-len=%d resp=%s\n",
+				url, resp.StatusCode, len(auth), len(body), truncate(raw, 200))
+		}
+		return resp, raw, nil
+	}
+
+	resp, raw, err := send()
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, raw, nil
+	}
+
+	// Likely first-run: user not yet provisioned. Provision and retry once.
+	if err := s.provisionAuthUser(ctx); err != nil {
+		return nil, nil, fmt.Errorf("provision after 401: %w", err)
+	}
+	return send()
+}

--- a/kefw2/json_parsing.go
+++ b/kefw2/json_parsing.go
@@ -1,9 +1,43 @@
 package kefw2
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
+
+// kefBool accepts either a JSON bool (true/false) or a string-encoded bool
+// ("true"/"false"/"1"/"0"). Different KEF settings paths use different
+// encodings for the same logical bool_ type.
+type kefBool bool
+
+func (b *kefBool) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if bytes.Equal(trimmed, []byte("true")) {
+		*b = true
+		return nil
+	}
+	if bytes.Equal(trimmed, []byte("false")) {
+		*b = false
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err != nil {
+		return fmt.Errorf("kefBool: cannot decode %s: %w", string(trimmed), err)
+	}
+	switch s {
+	case "true", "1":
+		*b = true
+	case "false", "0", "":
+		*b = false
+	default:
+		return fmt.Errorf("kefBool: unrecognized value %q", s)
+	}
+	return nil
+}
 
 // kefTypedValue represents the structure of a typed value from the KEF API.
 // The API returns values in a format like: [{“type”: “i32_”, “i32_”: 42}].
@@ -12,7 +46,7 @@ type kefTypedValue struct {
 	I32               *int         `json:"i32_,omitempty"`
 	I64               *int64       `json:"i64_,omitempty"`
 	String            *string      `json:"string_,omitempty"`
-	Bool              *string      `json:"bool_,omitempty"` // API returns "true"/"false" as strings
+	Bool              *kefBool     `json:"bool_,omitempty"` // API returns either JSON bool or "true"/"false" string
 	KefPhysicalSource *string      `json:"kefPhysicalSource,omitempty"`
 	KefSpeakerStatus  *string      `json:"kefSpeakerStatus,omitempty"`
 	KefCableMode      *string      `json:"kefCableMode,omitempty"`
@@ -102,8 +136,7 @@ func parseTypedBool(data []byte, err error) (bool, error) {
 		return false, fmt.Errorf("%w: missing bool_ value", ErrInvalidJSONResponse)
 	}
 
-	// KEF API returns booleans as strings "true" or "false"
-	return *val.Bool != "false", nil
+	return bool(*val.Bool), nil
 }
 
 // parseTypedSource parses a KEF API Source (kefPhysicalSource) response.

--- a/kefw2/json_parsing_test.go
+++ b/kefw2/json_parsing_test.go
@@ -142,6 +142,16 @@ func TestParseTypedBool(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "raw json true",
+			data: []byte(`[{"type":"bool_","bool_":true}]`),
+			want: true,
+		},
+		{
+			name: "raw json false",
+			data: []byte(`[{"type":"bool_","bool_":false}]`),
+			want: false,
+		},
+		{
 			name:    "empty array",
 			data:    []byte(`[]`),
 			wantErr: true,

--- a/kefw2/reboot.go
+++ b/kefw2/reboot.go
@@ -1,0 +1,212 @@
+/*
+Copyright © 2023-2026 Jens Hilligsøe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package kefw2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// ScheduledReboot describes the speaker's automatic-reboot schedule.
+//
+// DayOfWeek encoding has not yet been confirmed against the KEF Connect app.
+// Observed values are in the range 0-6; the most likely encodings are
+// 0=Sunday..6=Saturday or 1=Monday..7=Sunday. Test against the speaker UI
+// before relying on this field.
+type ScheduledReboot struct {
+	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	DayOfWeek int    `json:"day_of_week" yaml:"day_of_week"`
+	Time      string `json:"time" yaml:"time"`
+}
+
+const (
+	pathScheduledRebootEnabled   = "settings:/kef/scheduledReboot/enabled"
+	pathScheduledRebootDayOfWeek = "settings:/kef/scheduledReboot/dayOfWeek"
+	pathScheduledRebootTime      = "settings:/kef/scheduledReboot/time"
+)
+
+var rebootTimeRegexp = regexp.MustCompile(`^([01]\d|2[0-3]):[0-5]\d$`)
+
+// GetScheduledReboot returns the speaker's current scheduled-reboot configuration.
+func (s *KEFSpeaker) GetScheduledReboot(ctx context.Context) (ScheduledReboot, error) {
+	var sr ScheduledReboot
+
+	enabled, err := parseTypedBool(s.getData(ctx, pathScheduledRebootEnabled))
+	if err != nil {
+		return sr, fmt.Errorf("failed to get scheduled reboot enabled: %w", err)
+	}
+	sr.Enabled = enabled
+
+	day, err := parseTypedInt(s.getData(ctx, pathScheduledRebootDayOfWeek))
+	if err != nil {
+		return sr, fmt.Errorf("failed to get scheduled reboot day: %w", err)
+	}
+	sr.DayOfWeek = day
+
+	t, err := parseTypedString(s.getData(ctx, pathScheduledRebootTime))
+	if err != nil {
+		return sr, fmt.Errorf("failed to get scheduled reboot time: %w", err)
+	}
+	sr.Time = t
+
+	return sr, nil
+}
+
+// SetScheduledReboot updates the speaker's scheduled-reboot configuration.
+// dayOfWeek must be in 0-6 and timeStr must match HH:MM (24-hour).
+func (s *KEFSpeaker) SetScheduledReboot(ctx context.Context, sr ScheduledReboot) error {
+	if sr.DayOfWeek < 0 || sr.DayOfWeek > 6 {
+		return fmt.Errorf("dayOfWeek must be between 0 and 6, got %d", sr.DayOfWeek)
+	}
+	if !rebootTimeRegexp.MatchString(sr.Time) {
+		return fmt.Errorf("time must be in HH:MM 24-hour format, got %q", sr.Time)
+	}
+
+	if err := s.setAuthenticatedTypedValue(ctx, pathScheduledRebootDayOfWeek, sr.DayOfWeek); err != nil {
+		return fmt.Errorf("failed to set scheduled reboot day: %w", err)
+	}
+	if err := s.setAuthenticatedTypedValue(ctx, pathScheduledRebootTime, sr.Time); err != nil {
+		return fmt.Errorf("failed to set scheduled reboot time: %w", err)
+	}
+	if err := s.setAuthenticatedTypedValue(ctx, pathScheduledRebootEnabled, sr.Enabled); err != nil {
+		return fmt.Errorf("failed to set scheduled reboot enabled: %w", err)
+	}
+	return nil
+}
+
+// SetScheduledRebootEnabled toggles whether the scheduled reboot is active
+// without changing the day or time.
+func (s *KEFSpeaker) SetScheduledRebootEnabled(ctx context.Context, enabled bool) error {
+	return s.setAuthenticatedTypedValue(ctx, pathScheduledRebootEnabled, enabled)
+}
+
+// setAuthenticatedTypedValue is the HMAC-authenticated (TLS:4430) counterpart
+// of setTypedValue, required for writes under settings:/kef/scheduledReboot/*
+// which the unauthenticated HTTP:80 setData endpoint rejects with HTTP 401.
+func (s *KEFSpeaker) setAuthenticatedTypedValue(ctx context.Context, path string, value any) error {
+	var typeName string
+	var typeValue any
+
+	switch v := value.(type) {
+	case int:
+		typeName = typeNameI32
+		typeValue = v
+	case int64:
+		typeName = typeNameI64
+		typeValue = v
+	case string:
+		typeName = typeNameString
+		typeValue = v
+	case bool:
+		typeName = typeNameBool
+		typeValue = v
+	case TypeEncoder:
+		var strVal string
+		typeName, strVal = v.KEFTypeInfo()
+		typeValue = strVal
+	default:
+		return fmt.Errorf("unsupported type: %T", value)
+	}
+
+	jsonStr, err := json.Marshal(map[string]any{
+		"type":   typeName,
+		typeName: typeValue,
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling value: %w", err)
+	}
+	rawValue := json.RawMessage(jsonStr)
+
+	reqBody, err := json.Marshal(KEFPostRequest{
+		Path:  path,
+		Roles: "value",
+		Value: &rawValue,
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling request: %w", err)
+	}
+
+	resp, raw, err := s.doAuthenticatedPOST(ctx, authPathSetData, reqBody)
+	if err != nil {
+		return fmt.Errorf("authenticated setData %s: %w", path, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("authenticated setData %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+// Reboot triggers an immediate reboot of the speaker.
+//
+// The endpoint lives on the TLS-only authenticated API (port 4430) and
+// requires HMAC_SHA256 authentication; see kefw2/auth.go for the protocol
+// details recovered from the KEF Connect Android app.
+//
+// Because the speaker tears down its network stack immediately after
+// accepting the command, a connection reset / EOF after the request was
+// sent is treated as a successful reboot trigger.
+func (s *KEFSpeaker) Reboot(ctx context.Context) error {
+	body := []byte(`{"path":"powermanager:goReboot","role":"activate","value":"{}"}`)
+
+	resp, raw, err := s.doAuthenticatedPOST(ctx, authPathSetData, body)
+	if err != nil {
+		if isRebootDisconnect(err) {
+			return nil
+		}
+		return fmt.Errorf("reboot request: %w", err)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("reboot: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+}
+
+// isRebootDisconnect reports whether the error looks like the speaker
+// dropping the connection mid-response because it's rebooting.
+func isRebootDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		err = urlErr.Err
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "eof"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "use of closed network connection"):
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Adds reboot functionality to the kefw2 library and CLI, reverse-engineered from the KEF Connect Android app.

## Changes

### Group 1: JSON parsing fix (`58d8073`)
- Introduces a `kefBool` wrapper with a custom `UnmarshalJSON` that accepts both raw JSON booleans and string-encoded booleans (`"true"`/`"false"`), since the speaker firmware is inconsistent across endpoints.
- Updates the affected `Bool` field to use the new wrapper.

### Group 2: Reboot + HMAC auth (`2b37c56`)
- New `kefw2/auth.go`: HMAC-SHA256 request signer + `doAuthenticatedPOST` helper targeting the TLS `setData` endpoint on port 4430. Uses the hardcoded KEF Connect app credentials (username + MD5-derived password).
- New `kefw2/reboot.go`: `Reboot()`, `GetScheduledReboot`, `SetScheduledReboot`, `SetScheduledRebootEnabled`.
- New `cmd/kefw2/cmd/reboot.go`: CLI command with immediate reboot and scheduled-reboot flags.

## Verification
- `go build ./...`, `go test ./...`, `go vet ./...` all pass.
- Manually verified against multiple speakers with user-provisioned credentials — reboot and scheduled reboot both work.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>